### PR TITLE
Stop on error

### DIFF
--- a/config.h
+++ b/config.h
@@ -24,6 +24,7 @@
 #define HL_RESET    "\x1b[0m"
 #define HL_HOST     "\x1b[33m" /* yellow */
 #define HL_LABEL    "\x1b[36m" /* cyan */
+#define HL_ERROR    "\x1b[31m" /* red */
 
 /* checks */
 #define REQUIRE_SSH_AGENT

--- a/rset.1
+++ b/rset.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd December 23, 2020
+.Dd February 15, 2021
 .Dt RSET 1
 .Os
 .Sh NAME
@@ -61,6 +61,8 @@ The default is
 .It Fl t
 Allow TTY input by copying the content of each label to the remote host instead
 of opening a pipe to the interpreter.
+.It Fl e
+Stop executing if an error is encountered within a label.
 .It Fl v
 Print the HTTP log messages after each label is executed
 .It Fl x


### PR DESCRIPTION
Added `-e` flag to `rset`, which stops execution if an error is encountered within a label. New warning printed if an error is encountered within a label.

When running labels with `/bin/sh -x`, there is typically *a lot* of output, and with many labels it is unlikely that I would necessarily see errors or know where to begin looking for one. I typically add the `-e` flag to `/bin/sh` too, which is the primary case here. The red warning printed to the console helps with that, and stopping immediately leaves the error right in front of me on the terminal rather than way up in the scrollback. My personal preference is that this would be enabled by default. Thoughts?