### PR TITLE
tests: use ${RUBY} instead of `ruby'

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,4 @@
+RUBY = ruby
 CFLAGS = -I..
 OBJS = args cmd_pipe_stdin cmd_pipe_stdout copyfile getsocket parser ssh_command which
 RSET_LIBS = ../compat.o ../rutils.o ../input.o ../execute.o
@@ -11,11 +12,11 @@ rset.o: ${RSET_LIBS}
 	${CC} ${CFLAGS} $< rset.o ${LDFLAGS} -o $@
 
 test: ${OBJS}
-	@ruby test_rsub.rb
-	@ruby test_miniquark.rb
-	@ruby test_rinstall.rb
-	@ruby test_labelgrep.rb
-	@ruby test_rset.rb
+	@${RUBY} test_rsub.rb
+	@${RUBY} test_miniquark.rb
+	@${RUBY} test_rinstall.rb
+	@${RUBY} test_labelgrep.rb
+	@${RUBY} test_rset.rb
 
 clean:
 	rm -f *.core ${OBJS} *.o


### PR DESCRIPTION
This allows to change the ruby executable name; needed for example on OpenBSD where ruby is installed as `rubyXY` by default.

---

By the way, here the "GET a file using If-Modified-Since" (test_miniquark.rb:195) fails.

```
test_miniquark.rb:47:in `eq': "GET a file using If-Modified-Since" (RuntimeError)
> HTTP/1.1 200 OK\r
> Date: Sat, 11 Jul 2020 01:25:02 GMT\r
> Connection: close\r
> Last-Modified: Sat, 11 Jul 2020 01:25:02 GMT\r
> Content-Type: application/octet-stream\r
> Content-Length: 27\r
> \r
> ABCDEFGHIJKLMNOPQRSTUVWXYZ

< HTTP/1.1 304 Not Modified\r
< Date: Sat, 11 Jul 2020 01:25:02 GMT\r
< Connection: close\r
< \r
        from test_miniquark.rb:203:in `block (2 levels) in <main>'
        from /usr/local/lib/ruby/3.1/socket.rb:659:in `tcp'
        from test_miniquark.rb:195:in `block in <main>'
        from test_miniquark.rb:38:in `try'
        from test_miniquark.rb:192:in `<main>'
```

the test expect a mtime of "04 Oct 2022" (i.e. today) but miniquark sees an earlier mtime.