### PR TITLE
use the sh getopts builtin to parse arguments

### DIFF
--- a/rinstall.sh
+++ b/rinstall.sh
@@ -16,14 +16,14 @@ usage() {
 
 trap '' HUP
 
-while [ $# -gt 2 ]; do
-	case "$1" in
-		-o) OWNER="$2"; shift ;;
-		-m) MODE="$2"; shift ;;
-		 *) usage ;;
+while getopts m:o: arg; do
+	case "$arg" in
+		o) OWNER="$OPTARG" ;;
+		m) MODE="$OPTARG" ;;
+		?) usage ;;
 	esac
-	shift
 done
+shift $(($OPTIND - 1))
 [ $# -eq 2 ] || usage
 
 source=$1

--- a/rsub.sh
+++ b/rsub.sh
@@ -15,15 +15,15 @@ usage() {
 trap '' HUP
 append=1
 
-while [ $# -gt 1 ]; do
-	case "$1" in
-		-A) append=0 ;;
-		-r) shift; line_regex=$1 ;;
-		-l) shift; line_text=$1 ;;
-		 *) usage ;;
+while getopts Al:r: arg; do
+	case "$arg" in
+		A) append=0 ;;
+		r) line_regex="$OPTARG" ;;
+		l) line_text="$OPTARG" ;;
+		?) usage ;;
 	esac
-	shift
 done
+shift $(($OPTIND - 1))
 [ $# -eq 1 ] || usage
 
 source=$(mktemp rsub_XXXXXXXX)


### PR DESCRIPTION
Hi!

earlier today I was surprised for a moment by a cryptic error message from `rinstall`, the issue was that I typed `rinstall -m0644 ...` instead of `-m 0644`.  Most (all?) getopt(3) implementations don't require the space between the letter and its value.

so, I'm proposing a diff to use the sh builtin `getopts` instead of manually parsing the arguments.  Other than allowing to type `-m0644`, it also automatically handles `--` and provides better error messages.

A possible drawback is that currently

	$ rinstall -m 0644 -o foo -file-with-dash dest/dir

works, while now it would fail because of an unknown `-f` flag, while now it needs to be rewritten as

	$ rinstall -m 0644 -o foo -- -file-with-dash dest/dir

but I don't think (hope) that anyone is doing something like that.

Regarding the compatibility, `getopts` was included in the SUS in 1995 [according to wikipedia](https://en.wikipedia.org/wiki/Getopts) so can I assume it's widely available?

(or, we can leave the thing as-is)