### PR TITLE
Add experimental wrapper for running rset in parallel (tmux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 Makefile
 compat.c
 labelgrep
+log/
 miniquark
 rinstall
 rset
+rset-fanout
 rsub
 tests/args
 tests/cmd_pipe_stdin

--- a/Makefile.bsd
+++ b/Makefile.bsd
@@ -10,7 +10,7 @@ QUARK_COMPONENTS = sock http
 QUARK_OBJS = ${QUARK_COMPONENTS:=.o} compat.o miniquark.o
 QUARK_INC = ${QUARK_COMPONENTS:=.h} missing/compat.h
 
-PROGS = rset miniquark rinstall rsub labelgrep
+PROGS = rset miniquark rinstall rsub labelgrep rset-fanout
 
 all: versioncheck ${PROGS}
 
@@ -49,6 +49,7 @@ install: ${PROGS}
 	install rinstall ${DESTDIR}${PREFIX}/bin
 	install rsub ${DESTDIR}${PREFIX}/bin
 	install labelgrep ${DESTDIR}${PREFIX}/bin
+	install rset-fanout ${DESTDIR}${PREFIX}/bin
 	install -m 644 rset.1 ${DESTDIR}${MANPREFIX}/man1
 	install -m 644 miniquark.1 ${DESTDIR}${MANPREFIX}/man1
 	install -m 644 rinstall.1 ${DESTDIR}${MANPREFIX}/man1
@@ -62,6 +63,7 @@ uninstall:
 	rm ${DESTDIR}${PREFIX}/bin/rinstall
 	rm ${DESTDIR}${PREFIX}/bin/rsub
 	rm ${DESTDIR}${PREFIX}/bin/labelgrep
+	rm ${DESTDIR}${PREFIX}/bin/rset-fanout
 	rm ${DESTDIR}${MANPREFIX}/man1/rset.1
 	rm ${DESTDIR}${MANPREFIX}/man1/rinstall.1
 	rm ${DESTDIR}${MANPREFIX}/man1/rsub.1

--- a/rset-fanout.sh
+++ b/rset-fanout.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# A wrapper script for running rset(1) processes in parallel
+# Output for each host is written to a separate log file
+#
+# 2023 Eric Radman <ericshane@eradman.com>
+
+usage() {
+	>&2 echo "release: ${release}"
+	>&2 echo "usage: RSET_ARGS='...' rset-fanout hostname ..."
+	exit 1
+}
+[ $# -eq 0 ] && usage
+
+# Dry run to ensure routes are valid
+rset -n $RSET_ARGS $* > /dev/null || exit 1
+
+# Make or clear log dir
+logfile=${RSET_LOGFILE:-log/rset-output}
+[ -d log ] || mkdir log
+rm -f $logfile.*
+
+# Spin up detached session and write a log file for each new window
+session=rset
+tmux new-session -s $session -d || exit 1
+tmux set-hook -t $session -g after-new-window 'pipe-pane "cat > log/rset-output.#W."'
+
+# Start up tasks with a random delay based on the number of hosts
+let n=0
+let argc=$#
+while [ $# -gt 0 ]
+do
+	hostname=$1
+	cmd="sleep $((RANDOM % $argc)); rset $RSET_ARGS $hostname; mv $logfile.$hostname.{,\$?}"
+	tmux new-window -t $session:$((n+1)) -n $hostname "$cmd"
+	n=$((n+1)); shift
+done
+
+# First window no longer needed
+tmux kill-window -t $session:0
+
+function status {
+	clear
+	printf ">> \033[37mrset ${RSET_ARGS}\033[0m\n"
+	wc -l $logfile.* | grep -v ' total$'
+}
+
+# Wait for all windows to clear
+while tmux list-windows -t rset -F '#{window_name}' 2>&1
+do
+	status
+	sleep 1
+done
+status


### PR DESCRIPTION
- Each hostname is run in a separate tmux window
- Each host connection is sent to a separate log file
- Log files are terminated with exit status when complete
- Startup time for each host is randomized based on the number of arguments
- rset(1) arguments are provided using an environment variable for easier parsing

Example:

```
$ RSET_ARGS="-e -x pack" rset-fanout dev1 dev2 dev3 dev4 report1
```

Progressive output appears as follows

```
>> rset -e -x pack
     103 log/rset-output.dev1.0
       4 log/rset-output.dev2.1
       5 log/rset-output.dev3.0
       2 log/rset-output.dev4.0
       2 log/rset-output.report1.0
```