### PR TITLE
Change '-l' to require an option_name

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,5 +1,5 @@
 CPPFLAGS += -D_GNU_SOURCE -D_LINUX_PORT
 MANPREFIX ?= ${PREFIX}/share/man
-EXTRA_SRC = missing/setproctitle.c missing/strlcpy.c missing/strtonum.c
+EXTRA_SRC = missing/setproctitle.c missing/strlcpy.c missing/strlcat.c missing/strtonum.c
 
 include Makefile.bsd

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@
  - New environment_file option for defining variables
  - New environment option for defining variables inline
  - Improve parsing by prioritizing parameters before labels
+ - '-l' requires an option value
 
 = Release History
 

--- a/missing/compat.h
+++ b/missing/compat.h
@@ -2,6 +2,7 @@
 
 #if defined(_LINUX_PORT) && defined(__GLIBC__)
 size_t strlcpy(char *dst, const char *src, size_t dsize);
+size_t strlcat(char *dst, const char *src, size_t dsize);
 #endif
 
 #if defined(_MACOS_PORT) || defined(_LINUX_PORT)

--- a/missing/strlcat.c
+++ b/missing/strlcat.c
@@ -1,0 +1,55 @@
+/*	$OpenBSD: strlcat.c,v 1.19 2019/01/25 00:19:25 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998, 2015 Todd C. Miller <millert@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Appends src to string dst of size dsize (unlike strncat, dsize is the
+ * full size of dst, not space left).  At most dsize-1 characters
+ * will be copied.  Always NUL terminates (unless dsize <= strlen(dst)).
+ * Returns strlen(src) + MIN(dsize, strlen(initial dst)).
+ * If retval >= dsize, truncation occurred.
+ */
+size_t
+strlcat(char *dst, const char *src, size_t dsize)
+{
+	const char *odst = dst;
+	const char *osrc = src;
+	size_t n = dsize;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end. */
+	while (n-- != 0 && *dst != '\0')
+		dst++;
+	dlen = dst - odst;
+	n = dsize - dlen;
+
+	if (n-- == 0)
+		return(dlen + strlen(src));
+	while (*src != '\0') {
+		if (n != 0) {
+			*dst++ = *src;
+			n--;
+		}
+		src++;
+	}
+	*dst = '\0';
+
+	return(dlen + (src - osrc));	/* count does not include NUL */
+}

--- a/rset.1
+++ b/rset.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd November 3, 2023
+.Dd November 10, 2023
 .Dt RSET 1
 .Os
 .Sh NAME
@@ -21,9 +21,10 @@
 .Nd remote staging and execution tool
 .Sh SYNOPSIS
 .Nm rset
-.Op Fl elntv
+.Op Fl entv
 .Op Fl F Ar sshconfig_file
 .Op Fl f Ar routes_file
+.Op Fl l Ar option_name
 .Op Fl x Ar label_pattern
 .Ar hostname ...
 .Sh DESCRIPTION
@@ -39,8 +40,6 @@ The arguments are as follows:
 .Bl -tag -width Ds
 .It Fl e
 Stop executing if an error is encountered within a label.
-.It Fl l
-List the options associated with each label.
 .It Fl n
 Do not connect to remote hosts.
 Special text defined between { and } is still executed locally.
@@ -66,6 +65,11 @@ hostnames or IP addresses which are matched against
 .Ar hostname .
 The default is
 .Pa routes.pln .
+.It Fl l
+List the specified option state associated with each label.
+See
+.Sx OPTIONS
+for the set of supported arguments.
 .It Fl x
 Execute labels matching the specified regex.
 By default only labels beginning with [0-9a-z] are evaluated.

--- a/rutils.c
+++ b/rutils.c
@@ -104,24 +104,28 @@ hl_range(const char *s, const char *color, unsigned so, unsigned eo) {
 }
 
 /*
- * format_options - print a concise representation of options
+ * format_option - return the value of an option
  */
 
 char *
-format_options(Options *op) {
-	static char buf[2048];
-	int pos = 0;
+format_option(Options *op, const char *option) {
+	static char buf[PLN_LABEL_SIZE];
 
-	if (*op->interpreter)
-		pos += snprintf(buf+pos, sizeof(buf)-pos, "interpreter=%s,",
-		    op->interpreter);
-	if (*op->local_interpreter)
-		pos += snprintf(buf+pos, sizeof(buf)-pos, "local_interpreter=%s,",
-		    op->local_interpreter);
-	if (*op->execute_with)
-		pos += snprintf(buf+pos, sizeof(buf)-pos, "execute_with=%s,",
-		    op->execute_with);
-	buf[pos - (pos > 0 ? 1 : 0)] = '\0';
+	strlcpy(buf, option, sizeof buf);
+	strlcat(buf, "=", sizeof buf);
+
+	if (strcmp(option, "environment") == 0)
+		strlcat(buf, op->environment, sizeof buf);
+	else if (strcmp(option, "environment_file") == 0)
+		strlcat(buf, op->environment_file, sizeof buf);
+	else if (strcmp(option, "interpreter") == 0)
+		strlcat(buf, op->interpreter, sizeof buf);
+	else if (strcmp(option, "local_interpreter") == 0)
+		strlcat(buf, op->local_interpreter, sizeof buf);
+	else if (strcmp(option, "execute_with") == 0)
+		strlcat(buf, op->execute_with, sizeof buf);
+	else
+		buf[0] = '\0';
 
 	return buf;
 }

--- a/rutils.h
+++ b/rutils.h
@@ -22,4 +22,4 @@ char *xdirname(const char *path);
 int create_dir(const char *dir);
 void install_if_new(const char *src, const char *dst);
 void hl_range(const char *s, const char *color, unsigned so, unsigned eo);
-char *format_options(Options *op);
+char *format_option(Options *op, const char *option);

--- a/tests/expected/dry_run.out
+++ b/tests/expected/dry_run.out
@@ -1,4 +1,4 @@
 [33m[7mt460s[0m[33m               [0m  t460s/ common/
-[36m[7mc[0m[36mhroot              [0m  execute_with=doas
-[36m[7mc[0m[36mommon packages     [0m  interpreter=/bin/ksh -x,local_interpreter=/bin/sh -e,execute_with=doas
-[36m[7md[0m[36mesktop             [0m  interpreter=/bin/ksh -x,local_interpreter=/bin/sh -e,execute_with=doas
+[36m[7mc[0m[36mhroot              [0m  interpreter=
+[36m[7mc[0m[36mommon packages     [0m  interpreter=/bin/ksh -x
+[36m[7md[0m[36mesktop             [0m  interpreter=/bin/ksh -x

--- a/tests/expected/recursive.out
+++ b/tests/expected/recursive.out
@@ -1,6 +1,10 @@
 t460s, content_size: 29
-t460s, options: t460s/ common/
+t460s, option: t460s/ common/
 relay{1..3}.local, content_size: 19
-relay{1..3}.local, options: common/
+relay{1..3}.local, option: common/
 chroot, content_size: 146
-chroot, options: execute_with=doas
+chroot, environment=
+chroot, environment_file=
+chroot, interpreter=
+chroot, local_interpreter=
+chroot, execute_with=doas

--- a/tests/parser.c
+++ b/tests/parser.c
@@ -28,6 +28,7 @@ int main(int argc, char *argv[])
 	int i, j, l;
 	char *mode;
 	char paths[1024];
+	Options *options;
 
 	if (argc != 3) usage();
 	mode = argv[1];
@@ -62,14 +63,17 @@ int main(int argc, char *argv[])
 			read_host_labels(route_labels[i]);
 			printf("%s, content_size: %d\n",
 			    route_labels[i]->name, route_labels[i]->content_size);
-			printf("%s, options: %s\n",
+			printf("%s, option: %s\n",
 			    route_labels[i]->name, paths);
 		}
 		for (j=0; host_labels[j]; j++) {
-			printf("%s, content_size: %d\n",
-			    host_labels[j]->name, host_labels[j]->content_size);
-			printf("%s, options: %s\n",
-			    host_labels[j]->name, format_options(&host_labels[j]->options));
+			printf("%s, content_size: %d\n", host_labels[j]->name, host_labels[j]->content_size);
+			options = &host_labels[j]->options;
+			printf("%s, %s\n", host_labels[j]->name, format_option(options, "environment"));
+			printf("%s, %s\n", host_labels[j]->name, format_option(options, "environment_file"));
+			printf("%s, %s\n", host_labels[j]->name, format_option(options, "interpreter"));
+			printf("%s, %s\n", host_labels[j]->name, format_option(options, "local_interpreter"));
+			printf("%s, %s\n", host_labels[j]->name, format_option(options, "execute_with"));
 		}
 		break;
 	default:

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -164,7 +164,7 @@ try 'Run rset with no arguments' do
   _, err, status = Open3.capture3(cmd)
   eq err.gsub(/release: (\d\.\d)/, 'release: 0.0'),
      "release: 0.0\n" \
-     "usage: rset [-elntv] [-F sshconfig_file] [-f routes_file] [-x label_pattern] hostname ...\n"
+     "usage: rset [-entv] [-F sshconfig_file] [-f routes_file] [-l option_name] [-x label_pattern] hostname ...\n"
   eq status.success?, false
 end
 
@@ -208,7 +208,7 @@ try 'Report an unknown syntax' do
   fn = "#{@systmp}/routes.pln"
   FileUtils.mkdir_p("#{@systmp}/_sources")
   File.open(fn, 'w') { |f| f.write("php\n") }
-  cmd = "#{Dir.pwd}/../rset -ln localhost"
+  cmd = "#{Dir.pwd}/../rset -l interpreter -n localhost"
   out, err, status = Open3.capture3(cmd, chdir: @systmp)
   eq err, "routes.pln: unknown symbol at line 1: 'php'\n"
   eq status.success?, false
@@ -227,7 +227,7 @@ end
 try 'Report a bad regex' do
   fn = "#{@systmp}/routes.pln"
   File.open(fn, 'w') { |f| f.write('') }
-  cmd = "#{Dir.pwd}/../rset -ln -x 't[42' localhost"
+  cmd = "#{Dir.pwd}/../rset -n -x 't[42' localhost"
   out, err, status = Open3.capture3(cmd, chdir: @systmp)
   eq err[0..20], 'rset: bad expression:'
   eq status.success?, false
@@ -237,7 +237,7 @@ end
 try 'Report an unknown option' do
   fn = "#{@systmp}/routes.pln"
   File.open(fn, 'w') { |f| f.write("username=radman\n") }
-  cmd = "#{Dir.pwd}/../rset -ln 't[42'"
+  cmd = "#{Dir.pwd}/../rset -n -l interpreter 't[42'"
   out, err, status = Open3.capture3(cmd, chdir: @systmp)
   eq err, "routes.pln: unknown option 'username=radman'\n"
   eq status.success?, false
@@ -310,7 +310,7 @@ end
 
 try 'Show matching routes and hosts' do
   out, err, status = nil
-  cmd = "#{Dir.pwd}/../rset -ln t460s"
+  cmd = "#{Dir.pwd}/../rset -l interpreter -n t460s"
   Dir.chdir('input') do
     FileUtils.mkdir_p('_sources')
     out, err, status = Open3.capture3(cmd)


### PR DESCRIPTION
Now that there are five options (`environment`, `environment_file`, `interpreter`, `local_interpreter`, `execute_with`) listing all options in one line not does not read well.

The `-l` flag is probably seldom used, but is sometimes useful verifying that options are applied correctly (or as expected).