### PR TITLE
rinstall cleanup

### DIFF
--- a/tests/test_rinstall.rb
+++ b/tests/test_rinstall.rb
@@ -114,7 +114,7 @@ end
 
 is_busybox = ENV['SHELL'] == '/bin/ash'
 try 'Install a file from a remote URL containing special characters', (is_busybox) do
-  fn = "test!@()_+ #{@tests}.txt"
+  fn = "test-!@()_+$#{@tests}.txt"
   dst = "#{@systmp}/#{fn}"
   src = "#{@wwwtmp}/#{fn}"
   File.open(src, 'w') { |f| f.write('123') }
@@ -210,21 +210,4 @@ try 'Ensure that a relative target cannot be used' do
   eq err, "rinstall: #{fn} is not an absolute path\n"
   eq out, ''
   eq File.exist?(dst), false
-end
-
-try 'Refuse to install an empty file' do
-  fn = "test_#{@tests}.txt"
-  dst = "#{@systmp}/#{@tests}/#{fn}"
-  src = "#{@wwwtmp}/#{fn}"
-  Dir.mkdir "#{@systmp}/#{@tests}"
-  File.open(src, 'w') { |f| f.write('') }
-  File.open(dst, 'w') do |f|
-    f.chmod(0o642)
-    f.write("000\n123\n")
-  end
-  cmd = "INSTALL_URL=#{@install_url} #{Dir.pwd}/../rinstall -m 660 #{fn} #{dst}"
-  out, err, status = Open3.capture3(cmd, chdir: @systmp)
-  eq err, "rinstall: #{fn} is empty\n"
-  eq out, ''
-  eq status.exitstatus, 1
 end


### PR DESCRIPTION
- a default http port is aligned with the rest of the code
- a consistent style by addressing a mixed use of test/[ and $()/``
- prioritize curl on Linux systems and use wget as a fallback
- add parameters for curl to allow it printing an error message being in the silent mode and also keep working on redirections that is useful for pointing the INSTALL_URL to external resources
- compact form of cli parameters
- all messages at the failing conditions are printed to stderr
- remove the check for an empty file (the code and the test) to keep a consistency and transparency of getting files onto a remote system: a tar based upload and http based download should work the same for all files
- make sure all conditions have OR clause to avoid raising a failed status
- fix the test for downloading files with special characters in names by setting up an applicable for URLs file name
- rewrote the logic of a file creation to fix a bug when rinstall reports "file created" but in fact cp failed and a file wasn't created
- if cp fails, rinstall returns its exit status
- add vim instuctions to preserve TABs for editing