### PR TITLE
Add flag (-E) for setting remote environment variables

### DIFF
--- a/execute.h
+++ b/execute.h
@@ -29,9 +29,9 @@ char *findprog(char *prog);
 
 int verify_ssh_agent();
 int start_connection(char *socket_path, char *host_name, Label *route_label, int http_port, const char *ssh_config);
-int update_environment_file(char *host_name, char *socket_path, Label *host_label, int http_port);
-int ssh_command_pipe(char *host_name, char *socket_path, Label *host_label, int http_port);
-int ssh_command_tty(char *host_name, char *socket_path, Label *host_label, int http_port);
+int update_environment_file(char *host_name, char *socket_path, Label *host_label, int http_port, const char *env_override);
+int ssh_command_pipe(char *host_name, char *socket_path, Label *host_label, int http_port, const char *env_override);
+int ssh_command_tty(char *host_name, char *socket_path, Label *host_label, int http_port, const char *env_override);
 void end_connection(char *socket_path, char *host_name, int http_port);
 
 void apply_default(char *option, const char *user_option, const char *default_option);

--- a/rset.1
+++ b/rset.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd November 22, 2023
+.Dd November 28, 2023
 .Dt RSET 1
 .Os
 .Sh NAME
@@ -22,6 +22,7 @@
 .Sh SYNOPSIS
 .Nm rset
 .Op Fl entv
+.Op Fl E Ar environment
 .Op Fl F Ar sshconfig_file
 .Op Fl f Ar routes_file
 .Op Fl l Ar option_name
@@ -51,6 +52,9 @@ Allow TTY input by copying the content of each label to the remote host instead
 of opening a pipe to the interpreter.
 .It Fl v
 Print the HTTP log messages after each label is executed.
+.It Fl E
+Set one or more environment variables using the format
+.Sq name="value" ... .
 .It Fl F
 Specify a
 .Pa config
@@ -124,7 +128,7 @@ Environment state may set for the duration of the ssh session
 using
 .Xr renv 1
 using
-.Ql name="value"
+.Ql name=value
 as the first argument.
 .Sh FILES
 Available hosts and the pathnames to labeled scripts to run are read from

--- a/rset.c
+++ b/rset.c
@@ -60,6 +60,7 @@ int verbose_opt;
 int stop_on_err_opt;
 char *list_option_name;
 char *sshconfig_file;
+char *env_override;
 char *label_pattern = DEFAULT_LABEL_PATTERN;
 char *routes_file = ROUTES_FILE;
 
@@ -233,9 +234,9 @@ execute_remote(char *hostnames[], Label **route_labels, regex_t *label_reg) {
 					log_msg(label_exec_begin_msg, hostname, host_labels[j]->name, 0);
 
 					if (tty_opt)
-						exit_code = ssh_command_tty(hostname, socket_path, host_labels[j], http_port);
+						exit_code = ssh_command_tty(hostname, socket_path, host_labels[j], http_port, env_override);
 					else
-						exit_code = ssh_command_pipe(hostname, socket_path, host_labels[j], http_port);
+						exit_code = ssh_command_pipe(hostname, socket_path, host_labels[j], http_port, env_override);
 
 					log_msg(label_exec_end_msg, hostname, host_labels[j]->name, exit_code);
 
@@ -342,8 +343,8 @@ handle_exit(int sig) {
 static void
 usage() {
 	fprintf(stderr, "release: %s\n", RELEASE);
-	fprintf(stderr, "usage: rset [-entv] [-F sshconfig_file] [-f routes_file] "
-	    "[-l option_name] [-x label_pattern] hostname ...\n");
+	fprintf(stderr, "usage: rset [-entv] [-E environment] [-F sshconfig_file] "
+	    "[-f routes_file] [-l option_name] [-x label_pattern] hostname ...\n");
 	exit(1);
 }
 
@@ -356,7 +357,7 @@ set_options(int argc, char *argv[], char *hostnames[]) {
 
 	bzero(&op, sizeof op);
 
-	while ((ch = getopt(argc, argv, "entvF:f:l:x:")) != -1) {
+	while ((ch = getopt(argc, argv, "entvE:F:f:l:x:")) != -1) {
 		switch (ch) {
 		case 'e':
 			stop_on_err_opt = 1;
@@ -369,6 +370,10 @@ set_options(int argc, char *argv[], char *hostnames[]) {
 			break;
 		case 'v':
 			verbose_opt = 1;
+			break;
+		case 'E':
+			env_override = argv[optind-1];
+			free(env_split_lines(env_override, env_override, 1));
 			break;
 		case 'F':
 			sshconfig_file = argv[optind-1];

--- a/tests/ssh_command.c
+++ b/tests/ssh_command.c
@@ -16,7 +16,7 @@ Options current_options;
 void usage();
 
 void usage() {
-	fprintf(stderr, "usage: ./ssh_command S|P|T|E hostname\n"
+	fprintf(stderr, "usage: ./ssh_command S|P|T|E hostname [env_override]\n"
 	    "  S = Start session\n"
 	    "  P = Remote Execution over a pipe\n"
 	    "  T = Remote execution with TTY\n"
@@ -29,25 +29,29 @@ int main(int argc, char *argv[])
 	char *socket_path;
 	Label host_label = { .name="networking" };
 	int http_port = 6000;
+	char *env_override = 0;
 	char *host_name;
-	char* mode;
+	char *mode;
 
 	/* end_connection calls free() on socket_path */
 	socket_path = strdup("/tmp/test_rset_socket");
 
-	if (argc != 3) usage();
+	if (argc < 3) usage();
 	mode = argv[1];
 	host_name = argv[2];
+
+	if (argc == 4)
+		env_override = argv[3];
 
 	switch (mode[0]) {
 	case 'S':
 		start_connection(socket_path, host_name, &host_label, http_port, NULL);
 		break;
 	case 'P':
-		ssh_command_pipe(host_name, socket_path, &host_label, http_port);
+		ssh_command_pipe(host_name, socket_path, &host_label, http_port, env_override);
 		break;
 	case 'T':
-		ssh_command_tty(host_name, socket_path, &host_label, http_port);
+		ssh_command_tty(host_name, socket_path, &host_label, http_port, env_override);
 		break;
 	case 'E':
 		end_connection(socket_path, host_name, http_port);

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -171,9 +171,10 @@ end
 try 'Run rset with no arguments' do
   cmd = '../rset'
   _, err, status = Open3.capture3(cmd)
-  eq err.gsub(/release: (\d\.\d)/, 'release: 0.0'),
-     "release: 0.0\n" \
-     "usage: rset [-entv] [-F sshconfig_file] [-f routes_file] [-l option_name] [-x label_pattern] hostname ...\n"
+  eq err.gsub(/release: (\d\.\d)/, 'release: 0.0'), <<~USAGE
+    release: 0.0
+    usage: rset [-entv] [-E environment] [-F sshconfig_file] [-f routes_file] [-l option_name] [-x label_pattern] hostname ...
+  USAGE
   eq status.success?, false
 end
 


### PR DESCRIPTION
This may override values set by environment= and environment_file=, but does not interfere with scripts on the remote host that set variables using `renv name="value"`.