### PR TITLE
rinstall: cleanups and improved fetch logic

### DIFF
--- a/rinstall.1
+++ b/rinstall.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd October 28, 2023
+.Dd December 3, 2023
 .Dt RINSTALL 1
 .Os
 .Sh NAME
@@ -30,6 +30,10 @@
 .Op Fl m Ar mode
 .Ar source
 .Ar directory
+.Nm rinstall
+.Op Fl o Ar owner:group
+.Op Fl m Ar mode
+.Ar source
 .Sh DESCRIPTION
 .Nm
 is shipped to remote machines by
@@ -37,16 +41,25 @@ is shipped to remote machines by
 to provide a standard method of installing files made available over HTTP, or
 from the current working directory if it already exists.
 .Pp
+The
+.Ar target
+should be defined by an absolute path.
 If the
 .Ar target
 does not exist it is created.
-If the
-.Ar target
-exists but is not the same,
+If it exists but is not the same as
+.Ar source
+then
 .Xr diff 1
 is called to display the difference before the
 .Ar target
 is updated.
+If the
+.Ar target
+is omitted, the
+.Ar source
+is placed in the staging directory, preserving a relative path.
+.Pp
 The arguments are as follows:
 .Bl -tag -width Ds
 .It Fl o
@@ -64,6 +77,12 @@ The
 argument is a relative path that is appended to
 the environment variable
 .Ev INSTALL_URL .
+If
+.Ar target
+is not defined, files are stored relative to the staging directory
+defined by the
+.Ev SD
+environment variable.
 .Sh EXIT STATUS
 The
 .Nm
@@ -75,7 +94,7 @@ Target file was installed or updated
 .It 1
 No changes were made
 .It 2
-Incorrect parameters
+Unknown Operating System
 .It 3
 Unable to fetch requested file
 .El

--- a/rinstall.sh
+++ b/rinstall.sh
@@ -3,13 +3,14 @@
 # Install files from the local staging area or a remote URL
 
 ret=1
+fetched=0
+samedir=0
 : ${INSTALL_URL:=http://localhost:6000}
 unset http_proxy
 
 usage() {
 	>&2 echo "release: ${release}"
-	>&2 echo "usage: rinstall [-m mode] [-o owner]"
-	>&2 echo "                source target"
+	>&2 echo "usage: rinstall [-m mode] [-o owner] source [target]"
 	exit 1
 }
 
@@ -23,10 +24,37 @@ while getopts m:o: arg; do
 	esac
 done
 shift $(($OPTIND - 1))
-[ $# -eq 2 ] || usage
+[ $# -eq 1 -o $# -eq 2 ] || usage
 
-source=$1
-[ -d "$2" ] && target="$2/$(basename "$source")" || target=$2
+source="$1"
+spath="$(dirname $source)"
+
+if [ -z "$2" ]; then
+	# ensure the source is a relative path by removing leading slashes
+	srpath="$(echo "$spath" | sed 's|^/*||')"
+
+	[ -n "$SD" ] || {
+		>&2 echo "rinstall: staging directory \$SD is not defined"
+		exit 1
+	}
+
+	# prepare a relative path for the target
+	[ -d "$SD/$srpath" ] || mkdir -p "$SD/$srpath" || {
+		>&2 echo "rinstall: could not create a relative path: $srpath"
+		exit 1
+	}
+
+	if [ "$srpath" = "." ]; then
+		target="$SD/$(basename "$source")"
+	else
+		target="$SD/$srpath/$(basename "$source")"
+	fi
+	samedir=1
+elif [ -d "$2" ]; then
+	target="$2/$(basename "$source")"
+else
+	target="$2"
+fi
 
 case $(dirname "$target") in
 	/*) ;;
@@ -36,50 +64,80 @@ case $(dirname "$target") in
 		;;
 esac
 
-if [ ! -f "$1" ]; then
-	umask 044
-	source="$(basename "$1" | tr -C '0-9a-zA-Z_' '_')$(mktemp XXXXXX)"
-        case $(uname) in
+# If a source file doesn't exist, try to download it
+if [ ! -f "$source" ]; then
+	# The source file doesn't exist at this point and it shouldn't be
+	# an absolute path in this case
+	case $spath in
+		/*)
+			>&2 echo "rinstall: absolute path not permitted when fetching over HTTP: $source"
+			exit 1
+			;;
+		*)	;;
+	esac
+
+	# reconstruct the source's relative path
+	[ -d "$spath" ] || mkdir -p "$spath" || {
+		>&2 echo "rinstall: could not create a relative path: $spath"
+		exit 1
+	}
+
+	case $(uname) in
 		OpenBSD|NetBSD)
-			ftp -o "$source" -n "$INSTALL_URL/$1"
+			ftp -o "$source" -n "$INSTALL_URL/$source"
 			;;
 		FreeBSD|DragonFly)
-			fetch -qo "$source" "$INSTALL_URL/$1"
+			fetch -qo "$source" "$INSTALL_URL/$source"
 			;;
 		Linux|Darwin|SunOS)
 			if command -pv curl > /dev/null; then
-				curl -fsSLo "$source" "$INSTALL_URL/$1"
+				curl -fsSLo "$source" "$INSTALL_URL/$source"
 			else
-				wget -qO "$source" "$INSTALL_URL/$1"
+				wget -qO "$source" "$INSTALL_URL/$source"
 			fi
 			;;
 		*)
-			>&2 echo "Unknown OS"
-                        exit 2
+			>&2 echo "Unknown OS: $(uname)"
+			exit 2
 			;;
 	esac
 
 	[ $? -eq 0 ] || {
-		>&2 echo "rinstall: unable to fetch $INSTALL_URL/$1"
+		>&2 echo "rinstall: unable to fetch $INSTALL_URL/$source"
 		exit 3
 	}
-	umask 022
+	fetched=1
 fi
 
+# Source file exists at this point
 # create: 0 - files are the same, 1 - a new file,  2 - files are different
 if [ -e "$target" ]; then
-	diff -U 2 "$target" "$source" && create=0 || create=2
+	if [ $samedir -eq 1 ]; then
+		create=0
+		[ $fetched -eq 0 ] || {
+			ret=0
+			echo "rinstall: fetched $target"
+		}
+	else
+		diff -U 2 "$target" "$source" && create=0 || create=2
+	fi
 else
 	create=1
 fi
 
+# Copy file only if source and target are different
 if [ $create -ne 0 ]; then
-	cp "$source" "$target" && ret=0 || ret=$?
-	[ $create -eq 1 -a $ret -eq 0 ] && echo "rinstall: created $target" || :
+	cp "$source" "$target" && ret=0 || {
+		>&2 echo "rinstall: could not copy $source into $target"
+		exit 1
+	}
+	[ $create -eq 1 ] && echo "rinstall: created $target" || :
 fi
 
-[ -z "$OWNER" ] || chown $OWNER "$target"
-[ -z "$MODE" ] || chmod $MODE "$target"
+# Target file exists at this point
+# Try to change an owner and/or permissions but do not fail
+[ -z "$OWNER" ] || chown $OWNER "$target" || :
+[ -z "$MODE" ] || chmod $MODE "$target" || :
 
 exit $ret
 


### PR DESCRIPTION
- small clarifications and formatting adjustments in the map page
- fixed the regression when _rinstall_ could exit with _cp_'s exit code
- sources files are downloaded directly to the staging directory instead of temporary files. This removes duplication.
- when _rinstall_ fetches files via HTTP, it recreates a file path instead of always put files in the staging directory
- adjusted and added tests
- target is now optional, meaning "stage the file by fetching over HTTP"