### PR TITLE
Add no diff flag for rinstall(1)

### DIFF
--- a/rinstall.1
+++ b/rinstall.1
@@ -1,5 +1,6 @@
 .\"
 .\" Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
+.\" Copyright (c) 2021 Vasil Sarafov <vasil@sarafov.net>
 .\"
 .\" Permission to use, copy, modify, and distribute this software for any
 .\" purpose with or without fee is hereby granted, provided that the above
@@ -18,11 +19,18 @@
 .Os
 .Sh NAME
 .Nm rinstall
-.Nd fetch and install scripts from local or http source
+.Nd fetch and install scripts from local dirs or http sources
 .Sh SYNOPSIS
 .Nm rinstall
-.Op Fl m Ar mode
 .Op Fl o Ar owner:group
+.Op Fl m Ar mode
+.Op Fl x
+.Ar source
+.Ar target
+.Nm rinstall
+.Op Fl o Ar owner:group
+.Op Fl m Ar mode
+.Op Fl x
 .Ar source
 .Op Ar target
 .Sh DESCRIPTION
@@ -38,10 +46,13 @@ must be absolute path, and is created if it does not exist.
 If the
 .Ar target
 exists but is not the same as
-.Ar source ,
-then
+.Ar source , and the
+.Fl x
+flag is not activated,
 .Xr diff 1
-is used to display the difference before it is updated.
+is called to display the difference before the
+.Ar target
+is updated.
 .Pp
 If the
 .Ar target
@@ -59,18 +70,32 @@ before attempting to fetch a file from the location defined by the environment
 variable
 .Ev INSTALL_URL .
 .Pp
+.Nm
+is inspired by
+.Xr install 1
+found on Linux and *BSD systems.
+Under the hood
+.Nm
+calls
+.Xr chmod 1
+and
+.Xr chown 8 .
+.Pp
 The arguments are as follows:
 .Bl -tag -width Ds
 .It Fl m
-Mode to set when a file is updated.
+Mode to set when the file is updated.
 This argument is passed to
 .Xr chmod 1 .
 .It Fl o
 Owner and/or group to set.
 This argument is passed to
 .Xr chown 8 .
+.It Fl x
+Do not call
+.Xr diff 1
+to display the differences.
 .El
-.Pp
 .Sh EXIT STATUS
 The
 .Nm

--- a/rinstall.sh
+++ b/rinstall.sh
@@ -10,16 +10,18 @@ unset http_proxy
 
 usage() {
 	>&2 echo "release: ${release}"
-	>&2 echo "usage: rinstall [-m mode] [-o owner:group] source [target]"
+	>&2 echo "usage: rinstall [-m mode] [-o owner:group] [-x] source [target]"
 	exit 1
 }
 
 trap '' HUP
 
-while getopts m:o: arg; do
+NODIFF=0
+while getopts m:o:x: arg; do
 	case "$arg" in
 		o) OWNER="$OPTARG" ;;
 		m) MODE="$OPTARG" ;;
+		x) NODIFF=1 ;;
 		?) usage ;;
 	esac
 done
@@ -119,7 +121,9 @@ if [ -e "$target" ]; then
 			echo "rinstall: fetched $target"
 		}
 	else
-		diff -U 2 "$target" "$source" && create=0 || create=2
+		if [ ${NODIFF} -eq 0 ]; then
+			diff -U 2 "$target" "$source" && create=0 || create=2
+		fi
 	fi
 else
 	create=1


### PR DESCRIPTION
The -x flag for rinstall (1) surpresses the output of the diff between the target and the source file. In some cases the diffs are so big that rinstall's output creates too much noise.