### PR TITLE
rsub: escape ampersand in line argument

### DIFF
--- a/rsub.sh
+++ b/rsub.sh
@@ -55,9 +55,11 @@ if test -z "$line_regex$line_text"; then
 	    ' "$target" > $source
 	rm ${source}_b
 else
-	awk -v n=$append -v a="$line_regex" -v b="$line_text" \
-	    '{ n+=sub(a, b)}; {print}; END {if (n==0) print b}' \
-	    "$target" > $source
+	awk -v n=$append -v a="$line_regex" -v b="$line_text" '
+	    BEGIN { gsub("&", "\\\\&", b) }
+	    { n+=sub(a, b); print }
+	    END { if (n==0) print b }
+	    ' "$target" > $source
 fi
 
 test -e "$target" && diff -U 2 "$target" $source || {

--- a/tests/test_rsub.rb
+++ b/tests/test_rsub.rb
@@ -62,13 +62,13 @@ try 'Handle input containing special characters' do
   fn = "test ~!@()_+ #{@tests}.txt"
   dst = "#{@systmp}/#{fn}"
   File.open(dst, 'w') { |f| f.write("a = 2\nb = 3\n") }
-  cmd = "#{Dir.pwd}/../rsub -r 'a = [0-9]' -l 'a = 5' '#{dst}'"
+  cmd = "#{Dir.pwd}/../rsub -r 'a = [0-9]' -l 'a &= 5' '#{dst}'"
   out, err, status = Open3.capture3(cmd, chdir: @systmp)
   eq err, ''
   eq out.gsub(/[-+]{3}(.*)\n/, ''),
      "@@ -1,2 +1,2 @@\n" \
      "-a = 2\n" \
-     "+a = 5\n" \
+     "+a &= 5\n" \
      " b = 3\n"
   eq status.success?, true
 end


### PR DESCRIPTION
'&' is a special meta character in awk. When the -l flag contains an '&' character, rsub interpolates the entire matching string.