### PR TITLE
Hardlink $SD/_rutils/* to $SD for compatibility with busybox

### DIFF
--- a/execute.c
+++ b/execute.c
@@ -296,10 +296,10 @@ start_connection(char *socket_path, char *host_name, Label *route_label, int htt
 		return -1;
 
 	array_to_str(route_label->export_paths, paths, sizeof(paths), " ");
-	snprintf(cmd, PATH_MAX, "tar " TAR_OPTIONS " -cf - %s "
-	    "-C " REPLICATED_DIRECTORY " ./ | "
-	    "exec ssh -q -S %s %s tar -xf - -C " REMOTE_TMP_PATH,
-	    paths, socket_path, host_name, http_port);
+	snprintf(cmd, PATH_MAX, "tar " TAR_OPTIONS " -cf - " REPLICATED_DIRECTORY " %s "
+	    "| ssh -q -S %s %s 'tar -xf - -C " REMOTE_TMP_PATH "; cd "
+	    REMOTE_TMP_PATH "; find " REPLICATED_DIRECTORY " -type f -exec ln {} . \\;'",
+	    paths, socket_path, host_name, http_port, http_port);
 
 	if (system(cmd) != 0) {
 		warn("transfer failed for " REPLICATED_DIRECTORY);

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -120,11 +120,11 @@ try 'Start an ssh session' do
   out, err, status = Open3.capture3({ 'PATH' => "#{Dir.pwd}/stubs" }, cmd)
   eq err, ''
   eq status.success?, true
-  eq out, <<~RESULT
+  eq out, <<~'RESULT'
     ssh -fN -R 6000:localhost:6000 -S /tmp/test_rset_socket -M 10.0.0.99
     ssh -S /tmp/test_rset_socket 10.0.0.99 'mkdir /tmp/rset_staging_6000'
-    tar -cf - -C _rutils ./
-    ssh -q -S /tmp/test_rset_socket 10.0.0.99 tar -xf - -C /tmp/rset_staging_6000
+    tar -cf - _rutils
+    ssh -q -S /tmp/test_rset_socket 10.0.0.99 'tar -xf - -C /tmp/rset_staging_6000; cd /tmp/rset_staging_6000; find _rutils -type f -exec ln {} . \;'
   RESULT
 end
 


### PR DESCRIPTION
For compatibility with busybox tar(1), which applies `-C` to all paths, not only remaining paths:

```
BSD tar
  -C <dir>  Change to <dir> before processing remaining files

busybox tar
  -C DIR  Change to DIR before operation
```

Instead of creating a tar with _rutils/* scripts at the base directory, hardlink _rutils scripts.
