### PR TITLE
Use local stagedir

### DIFF
--- a/rutils.c
+++ b/rutils.c
@@ -31,7 +31,7 @@
 #include "rutils.h"
 
 /*
- * Mimic dirname(3) on OpenBSD which does not modify it's input
+ * Mimic dirname(3) except do not modify input
  */
 char *
 xdirname(const char *path) {
@@ -39,6 +39,17 @@ xdirname(const char *path) {
 
 	strlcpy(dname, path, sizeof(dname));
 	return dirname(dname);
+}
+
+/*
+ * Mimic basename(3) except do not modify input
+ */
+char *
+xbasename(const char *path) {
+	static char dname[PATH_MAX];
+
+	strlcpy(dname, path, sizeof(dname));
+	return basename(dname);
 }
 
 /*

--- a/rutils.h
+++ b/rutils.h
@@ -19,6 +19,7 @@
 /* forwards */
 
 char *xdirname(const char *path);
+char *xbasename(const char *path);
 int create_dir(const char *dir);
 void install_if_new(const char *src, const char *dst);
 void hl_range(const char *s, const char *color, unsigned so, unsigned eo);

--- a/tests/stubs/cp
+++ b/tests/stubs/cp
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "cp" $@

--- a/tests/stubs/mkdir
+++ b/tests/stubs/mkdir
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "mkdir" $@

--- a/tests/stubs/rm
+++ b/tests/stubs/rm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "rm" $@

--- a/tests/stubs/touch
+++ b/tests/stubs/touch
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "touch" $@

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -115,29 +115,33 @@ try 'Locate an executable in the current path' do
   eq out, "/bin/sh\n"
 end
 
-try 'Start an ssh session' do
+try 'Start ssh session' do
   cmd = './ssh_command S 10.0.0.99'
   out, err, status = Open3.capture3({ 'PATH' => "#{Dir.pwd}/stubs" }, cmd)
   eq err, ''
   eq status.success?, true
   eq out, <<~RESULT
+    mkdir /tmp/rset_staging_6000
+    cp -r _rutils/* /tmp/rset_staging_6000
+    touch /tmp/rset_staging_6000/local.env
     ssh -fN -R 6000:localhost:6000 -S /tmp/test_rset_socket -M 10.0.0.99
-    ssh -S /tmp/test_rset_socket 10.0.0.99 mkdir /tmp/rset_staging_6000
-    tar -cf - -C _rutils ./
-    ssh -q -S /tmp/test_rset_socket 10.0.0.99 tar -xf - -C /tmp/rset_staging_6000
+    tar -cf - -C /tmp rset_staging_6000
+    ssh -q -S /tmp/test_rset_socket 10.0.0.99 'tar -xf - -C /tmp'
   RESULT
 end
 
-try 'Start an ssh session with exported paths' do
+try 'Start ssh session with exported paths' do
   cmd = './ssh_command S 10.0.0.99 "input expected"'
   out, err, status = Open3.capture3({ 'PATH' => "#{Dir.pwd}/stubs" }, cmd)
   eq err, ''
   eq status.success?, true
   eq out, <<~RESULT
+    mkdir /tmp/rset_staging_6000
+    cp -r _rutils/* input expected /tmp/rset_staging_6000
+    touch /tmp/rset_staging_6000/local.env
     ssh -fN -R 6000:localhost:6000 -S /tmp/test_rset_socket -M 10.0.0.99
-    ssh -S /tmp/test_rset_socket 10.0.0.99 mkdir /tmp/rset_staging_6000
-    tar -cf - input expected -C _rutils ./
-    ssh -q -S /tmp/test_rset_socket 10.0.0.99 tar -xf - -C /tmp/rset_staging_6000
+    tar -cf - -C /tmp rset_staging_6000
+    ssh -q -S /tmp/test_rset_socket 10.0.0.99 'tar -xf - -C /tmp'
   RESULT
 end
 
@@ -173,6 +177,7 @@ try 'End an ssh session' do
   eq err, ''
   eq status.success?, true
   eq out, <<~RESULT
+    rm -rf /tmp/rset_staging_6000
     ssh -S /tmp/test_rset_socket 10.0.0.99 rm -rf /tmp/rset_staging_6000
     ssh -q -S /tmp/test_rset_socket -O exit 10.0.0.99
   RESULT


### PR DESCRIPTION
Eliminates one round-trip over SSH since 'tar -x' creates the staging remote directory.  Simplified use of tar(1) '-C' argument is compatible with busybox.