### PR TITLE
Detect and use native strlcpy(3), strlcat(3) on Linux

### DIFF
--- a/Makefile.linux-compat
+++ b/Makefile.linux-compat
@@ -1,5 +1,5 @@
 CPPFLAGS += -D_GNU_SOURCE -D_LINUX_PORT
 MANPREFIX ?= ${PREFIX}/share/man
-EXTRA_SRC = missing/setproctitle.c missing/strtonum.c
+EXTRA_SRC = missing/setproctitle.c missing/strlcpy.c missing/strlcat.c missing/strtonum.c
 
 include Makefile.bsd

--- a/configure
+++ b/configure
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+test_libc_features() {
+	CFLAGS="-D_GNU_SOURCE"
+	: ${CC:=cc}
+	2>/dev/null $CC -xc $CFLAGS - <<-EOF
+	#include <string.h>
+	int main(void) {
+		char dst[4];
+		strlcpy(dst, "1234", sizeof dst);
+		return 0;
+	}
+	EOF
+}
+
 usage() {
 	cat <<-HELP
 	Usage: configure [-h]
@@ -30,7 +43,7 @@ case "${TARGET_OS:-`uname`}" in
 		copy_mk macos;
 		;;
 	Linux)
-		copy_mk linux;
+		test_libc_features && copy_mk linux || copy_mk linux-compat
 		;;
 	*)
 		copy_mk bsd

--- a/missing/compat.h
+++ b/missing/compat.h
@@ -1,6 +1,6 @@
 /* compat.h */
 
-#if defined(_LINUX_PORT) && defined(__GLIBC__)
+#if defined(_LINUX_PORT)
 size_t strlcpy(char *dst, const char *src, size_t dsize);
 size_t strlcat(char *dst, const char *src, size_t dsize);
 #endif


### PR DESCRIPTION
Rather than setting individual feature flags, determine if libc contains all of the latest features that rset uses.  If not, use the legacy/compatibility build.

- Set _GNU_SOURCE since some invocations of `cc` do not set this implicitly
- Does not verify that the compiler works