### PR TITLE
Add log format '%s' for generated session ID

### DIFF
--- a/Makefile.linux-compat
+++ b/Makefile.linux-compat
@@ -1,5 +1,5 @@
 CPPFLAGS += -D_GNU_SOURCE -D_LINUX_PORT
 MANPREFIX ?= ${PREFIX}/share/man
-EXTRA_SRC = missing/setproctitle.c missing/strlcpy.c missing/strlcat.c missing/strtonum.c
+EXTRA_SRC = missing/setproctitle.c missing/strlcpy.c missing/strlcat.c missing/strtonum.c missing/arc4random.c
 
 include Makefile.bsd

--- a/configure
+++ b/configure
@@ -5,9 +5,12 @@ test_libc_features() {
 	: ${CC:=cc}
 	2>/dev/null $CC -xc $CFLAGS - <<-EOF
 	#include <string.h>
+	#include <stdlib.h>
 	int main(void) {
 		char dst[4];
+		unsigned rnd;
 		strlcpy(dst, "1234", sizeof dst);
+		rnd = arc4random();
 		return 0;
 	}
 	EOF

--- a/missing/arc4random.c
+++ b/missing/arc4random.c
@@ -1,0 +1,11 @@
+#include <inttypes.h>
+#include <sys/random.h>
+
+uint32_t
+arc4random(void)
+{
+	uint32_t val;
+	getrandom(&val, sizeof val, GRND_RANDOM);
+
+	return val;
+}

--- a/missing/compat.h
+++ b/missing/compat.h
@@ -3,6 +3,7 @@
 #if defined(_LINUX_PORT)
 size_t strlcpy(char *dst, const char *src, size_t dsize);
 size_t strlcat(char *dst, const char *src, size_t dsize);
+unsigned int arc4random(void);
 #endif
 
 #if defined(_MACOS_PORT) || defined(_LINUX_PORT)

--- a/rset.1
+++ b/rset.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd November 28, 2023
+.Dd January 22, 2024
 .Dt RSET 1
 .Os
 .Sh NAME
@@ -104,6 +104,8 @@ exit code
 label name
 .It \%%h
 hostname
+.It \%%s
+session identifier
 .It \%%T
 rfc-3339 timestamp
 .It \%%%

--- a/rset.c
+++ b/rset.c
@@ -45,8 +45,7 @@ static void compare_argv_routes(char *hostnames[], Label **route_labels);
 static int execute_remote(char *hostnames[], Label **route_labels, regex_t *label_reg);
 static int dry_run(char *hostnames[], Label **route_labels, regex_t *label_reg);
 
-/* globals used by input.h */
-
+/* globals from input.h */
 FILE* yyin;
 char* yyfn;
 int n_labels;
@@ -54,6 +53,7 @@ Label **route_labels;    /* parent */
 Label **host_labels;     /* child */
 Options current_options;
 
+/* globals */
 int dryrun_opt;
 int tty_opt;
 int verbose_opt;
@@ -214,6 +214,7 @@ execute_remote(char *hostnames[], Label **route_labels, regex_t *label_reg) {
 				else
 					continue;
 
+				generate_session_id();
 				log_msg(host_connect_msg, hostname, "", 0);
 
 				len = PLN_LABEL_SIZE + sizeof(LOCAL_SOCKET_PATH);

--- a/rutils.c
+++ b/rutils.c
@@ -30,6 +30,17 @@
 #include "config.h"
 #include "rutils.h"
 
+unsigned session_id;
+
+/*
+ * Update global session ID before starting a new SSH session
+ */
+unsigned
+generate_session_id() {
+	while ((session_id = arc4random()) == 0);
+	return session_id;
+}
+
 /*
  * Mimic dirname(3) on OpenBSD which does not modify it's input
  */
@@ -163,6 +174,9 @@ log_msg(char *template, char *hostname, char *label_name, int exit_code) {
 					break;
 				case 'l':
 					index += strlcpy(buf+index, label_name, sizeof(buf)-index);
+					break;
+				case 's':
+					index += snprintf(buf+index, sizeof(buf)-index, "%08"PRIx32, session_id);
 					break;
 				case 'T':
 					strftime(tmstr, sizeof(tmstr), LOG_TIMESTAMP_FORMAT, tm);

--- a/rutils.h
+++ b/rutils.h
@@ -14,10 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <inttypes.h>
+
 #include "input.h"
 
 /* forwards */
 
+unsigned generate_session_id();
 char *xdirname(const char *path);
 int create_dir(const char *dir);
 void install_if_new(const char *src, const char *dst);

--- a/tests/log_msg.c
+++ b/tests/log_msg.c
@@ -13,10 +13,13 @@ Options current_options;
 
 int main(int argc, char **argv)
 {
-	if (argc != 2) {
-		fprintf(stderr, "usage: ./log template\n");
+	if (argc < 2) {
+		fprintf(stderr, "usage: ./log template [S]\n");
 		return 1;
 	}
+
+	if ((argc == 3) && (argv[2][0] == 'S'))
+		generate_session_id();
 
 	log_msg(argv[1], "localhost", "network", 2);
 

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -270,22 +270,34 @@ end
 # Custom Logging
 
 try 'Log start message' do
-  cmd = "./log_msg '== Starting on %h at %T =='"
+  cmd = "./log_msg '%s == Starting on %h at %T =='"
   out, err, status = Open3.capture3(cmd)
   eq err, ''
   eq out.gsub(/[0-9]/, '0').sub(/[+-]{1}0{4} /, '+0100 '), <<~RESULT
-    == Starting on localhost at 0000-00-00 00:00:00+0100 ==
+    00000000 == Starting on localhost at 0000-00-00 00:00:00+0100 ==
   RESULT
   eq status.success?, true
 end
 
 try 'Log exit code and other characters' do
-  cmd = "./log_msg '== Running %l %% (%e) =='"
+  cmd = "./log_msg '%s == Running %l %% (%e) =='"
   out, err, status = Open3.capture3(cmd)
   eq err, ''
   eq out, <<~RESULT
-    == Running network % (2) ==
+    00000000 == Running network % (2) ==
   RESULT
+  eq status.success?, true
+end
+
+try 'Ensure session IDs are unique' do
+  cmd = ""
+  6.times { cmd += "./log_msg '%s' S;" }
+  out, err, status = Open3.capture3(cmd)
+  eq err, ''
+  eq out.split.uniq.length, 6
+  out.each_line do |line|
+    eq line.sub(/[0-9a-f]{8}/, 'ffffffff'), "ffffffff\n"
+  end
   eq status.success?, true
 end
 


### PR DESCRIPTION
To facilitate log processing where the output of multiple SSH session is sent to a log file.

In general, connect/exec_start/exec_end/exec_error/disconnect messages can be grouped by scanning for the pattern `/^[0-9a-f]{8}/`.

arc4random(3) was added to glibc 2.36, fall back to getrandom(2).