### PR TITLE
Simplify dry-run and remove list option

### DIFF
--- a/rset.1
+++ b/rset.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd January 22, 2024
+.Dd January 24, 2024
 .Dt RSET 1
 .Os
 .Sh NAME
@@ -25,7 +25,6 @@
 .Op Fl E Ar environment
 .Op Fl F Ar sshconfig_file
 .Op Fl f Ar routes_file
-.Op Fl l Ar option_name
 .Op Fl x Ar label_pattern
 .Ar hostname ...
 .Sh DESCRIPTION
@@ -42,11 +41,10 @@ The arguments are as follows:
 .It Fl e
 Stop executing if an error is encountered within a label.
 .It Fl n
-Do not connect to remote hosts.
+Do not connect to remote hosts. May be comed with
+.Fl x
+to highlight label names that match.
 Special text defined between { and } is still executed locally.
-Hostnames are highlighted to show what characters the
-.Ar hostname
-matched.
 .It Fl t
 Allow TTY input by copying the content of each label to the remote host instead
 of opening a pipe to the interpreter.
@@ -69,13 +67,6 @@ hostnames or IP addresses which are matched against
 .Ar hostname .
 The default is
 .Pa routes.pln .
-.It Fl l
-List the specified option state associated with each label.
-Only valid with
-.Fl n .
-See
-.Sx OPTIONS
-for the set of supported arguments.
 .It Fl x
 Execute labels matching the specified regex.
 By default only labels beginning with [0-9a-z] are evaluated.

--- a/rutils.c
+++ b/rutils.c
@@ -116,33 +116,6 @@ hl_range(const char *s, const char *color, unsigned so, unsigned eo) {
 }
 
 /*
- * format_option - return the value of an option
- */
-
-char *
-format_option(Options *op, const char *option) {
-	static char buf[PLN_LABEL_SIZE];
-
-	strlcpy(buf, option, sizeof buf);
-	strlcat(buf, "=", sizeof buf);
-
-	if (strcmp(option, "environment") == 0)
-		strlcat(buf, op->environment, sizeof buf);
-	else if (strcmp(option, "environment_file") == 0)
-		strlcat(buf, op->environment_file, sizeof buf);
-	else if (strcmp(option, "interpreter") == 0)
-		strlcat(buf, op->interpreter, sizeof buf);
-	else if (strcmp(option, "local_interpreter") == 0)
-		strlcat(buf, op->local_interpreter, sizeof buf);
-	else if (strcmp(option, "execute_with") == 0)
-		strlcat(buf, op->execute_with, sizeof buf);
-	else
-		buf[0] = '\0';
-
-	return buf;
-}
-
-/*
  * log_msg - write log message and interpolate variables
  */
 

--- a/rutils.h
+++ b/rutils.h
@@ -25,5 +25,4 @@ char *xdirname(const char *path);
 int create_dir(const char *dir);
 void install_if_new(const char *src, const char *dst);
 void hl_range(const char *s, const char *color, unsigned so, unsigned eo);
-char *format_option(Options *op, const char *option);
 void log_msg(char *template, char *hostname, char *label_name, int exit_code);

--- a/tests/expected/dry_run.out
+++ b/tests/expected/dry_run.out
@@ -1,4 +1,4 @@
-[33m[7mt460s[0m[33m               [0m  t460s/ common/
-[36m[7mc[0m[36mhroot              [0m  interpreter=
-[36m[7mc[0m[36mommon packages     [0m  interpreter=/bin/ksh -x
-[36m[7md[0m[36mesktop             [0m  interpreter=/bin/ksh -x
+[33m[7mt460s[0m[33m[0m
+[36m[7mc[0m[36mhroot[0m
+[36m[7mc[0m[36mommon packages[0m
+[36m[7md[0m[36mesktop[0m

--- a/tests/expected/recursive.out
+++ b/tests/expected/recursive.out
@@ -3,8 +3,3 @@ t460s, option: t460s/ common/
 relay{1..3}.local, content_size: 19
 relay{1..3}.local, option: common/
 chroot, content_size: 146
-chroot, environment=
-chroot, environment_file=
-chroot, interpreter=
-chroot, local_interpreter=
-chroot, execute_with=doas

--- a/tests/parser.c
+++ b/tests/parser.c
@@ -28,7 +28,6 @@ int main(int argc, char *argv[])
 	int i, j, l;
 	char *mode;
 	char path_repr[PLN_LABEL_SIZE];
-	Options *options;
 
 	if (argc != 3) usage();
 	mode = argv[1];
@@ -68,12 +67,6 @@ int main(int argc, char *argv[])
 		}
 		for (j=0; host_labels[j]; j++) {
 			printf("%s, content_size: %d\n", host_labels[j]->name, host_labels[j]->content_size);
-			options = &host_labels[j]->options;
-			printf("%s, %s\n", host_labels[j]->name, format_option(options, "environment"));
-			printf("%s, %s\n", host_labels[j]->name, format_option(options, "environment_file"));
-			printf("%s, %s\n", host_labels[j]->name, format_option(options, "interpreter"));
-			printf("%s, %s\n", host_labels[j]->name, format_option(options, "local_interpreter"));
-			printf("%s, %s\n", host_labels[j]->name, format_option(options, "execute_with"));
 		}
 		break;
 	default:

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -186,7 +186,7 @@ try 'Run rset with no arguments' do
   _, err, status = Open3.capture3(cmd)
   eq err.gsub(/release: (\d\.\d)/, 'release: 0.0'), <<~USAGE
     release: 0.0
-    usage: rset [-entv] [-E environment] [-F sshconfig_file] [-f routes_file] [-l option_name] [-x label_pattern] hostname ...
+    usage: rset [-entv] [-E environment] [-F sshconfig_file] [-f routes_file] [-x label_pattern] hostname ...
   USAGE
   eq status.success?, false
 end
@@ -231,7 +231,7 @@ try 'Report an unknown syntax' do
   fn = "#{@systmp}/routes.pln"
   FileUtils.mkdir_p("#{@systmp}/_sources")
   File.open(fn, 'w') { |f| f.write("php\n") }
-  cmd = "#{Dir.pwd}/../rset -l interpreter -n localhost"
+  cmd = "#{Dir.pwd}/../rset -n localhost"
   out, err, status = Open3.capture3(cmd, chdir: @systmp)
   eq err, "routes.pln: unknown symbol at line 1: 'php'\n"
   eq status.success?, false
@@ -260,7 +260,7 @@ end
 try 'Report an unknown option' do
   fn = "#{@systmp}/routes.pln"
   File.open(fn, 'w') { |f| f.write("username=radman\n") }
-  cmd = "#{Dir.pwd}/../rset -n -l interpreter 't[42'"
+  cmd = "#{Dir.pwd}/../rset -n 't[42'"
   out, err, status = Open3.capture3(cmd, chdir: @systmp)
   eq err, "routes.pln: unknown option 'username=radman'\n"
   eq status.success?, false
@@ -406,7 +406,7 @@ end
 
 try 'Show matching routes and hosts' do
   out, err, status = nil
-  cmd = "#{Dir.pwd}/../rset -l interpreter -n t460s"
+  cmd = "#{Dir.pwd}/../rset -n t460s"
   Dir.chdir('input') do
     FileUtils.mkdir_p('_sources')
     out, err, status = Open3.capture3(cmd)


### PR DESCRIPTION
Early on `-l` was used in development to verify that options (`interpreter=`, `execute_with=`, ...) were inherited correctly.

In practice, the ability to display these options does not demonstrate that execution is handled properly since the dry-run (`-n`) option takes a different code path.

If users want the ability to print an execution plan we should come up with a more comprehensive display log/format.

In the future `-l` option may be re-appropriated to specify a log directory.