### PR TITLE
Error messages for failed connection or stagedir initialization

### DIFF
--- a/execute.c
+++ b/execute.c
@@ -308,11 +308,8 @@ start_connection(char *socket_path, char *host_name, Label *route_label, int htt
 	snprintf(cmd, PATH_MAX, "tar " TAR_OPTIONS " -cf - -C " REPLICATED_DIRECTORY " . "
 	    "| ssh -q -S %s %s 'mkdir %s; tar -xf - -C %s'",
 	    socket_path, host_name, stagedir(http_port), stagedir(http_port));
-
-	if (system(cmd) != 0) {
-		warn("transfer failed for " REPLICATED_DIRECTORY);
+	if (system(cmd) != 0)
 		return -1;
-	}
 
 	path = route_label->export_paths;
 	if (path && *path) {
@@ -322,10 +319,8 @@ start_connection(char *socket_path, char *host_name, Label *route_label, int htt
 		    "| ssh -q -S %s %s 'tar -xf - -C %s'",
 		    path_repr, socket_path, host_name, stagedir(http_port));
 
-		if (system(cmd) != 0) {
-			warn("transfer failed for %s", path_repr);
+		if (system(cmd) != 0)
 			return -1;
-		}
 	}
 	return 0;
 }
@@ -375,10 +370,8 @@ update_environment_file(char *host_name, char *socket_path, Label *host_label, i
 	    "renv %s %s | ssh -q -S %s %s 'cat > %s/final.env; touch %s/local.env'",
 	    op.environment_file, tmp_src, socket_path, host_name,
 	    stagedir(http_port), stagedir(http_port));
-	if (system(cmd) != 0) {
-		warn("transfer failed for " REPLICATED_DIRECTORY);
+	if (system(cmd) != 0)
 		return -1;
-	}
 	unlink(tmp_src);
 
 	return 0;

--- a/rset.1
+++ b/rset.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd January 24, 2024
+.Dd February 15, 2024
 .Dt RSET 1
 .Os
 .Sh NAME
@@ -74,6 +74,7 @@ By default only labels beginning with [0-9a-z] are evaluated.
 .Sh ENVIRONMENT
 Status messages for each stage of execution may be customized by setting
 .Ev RSET_HOST_CONNECT ,
+.Ev RSET_HOST_CONNECT_FAIL ,
 .Ev RSET_LABEL_EXEC_BEGIN ,
 .Ev RSET_LABEL_EXEC_END ,
 .Ev RSET_LABEL_EXEC_ERROR ,

--- a/rset.c
+++ b/rset.c
@@ -171,6 +171,7 @@ execute_remote(char *hostnames[], Label **route_labels, regex_t *label_reg) {
 	Options op;
 
 	char *host_connect_msg = HL_HOST "%h" HL_RESET;
+	char *host_connect_fail = HL_ERROR "%h initialization failed" HL_RESET;
 	char *label_exec_begin_msg = HL_LABEL "%l" HL_RESET;
 	char *label_exec_end_msg = 0;
 	char *host_disconnect_msg = 0;
@@ -182,6 +183,7 @@ execute_remote(char *hostnames[], Label **route_labels, regex_t *label_reg) {
 	/* custom log format */
 	if (getenv("RSET_HOST_CONNECT")) {
 		host_connect_msg = getenv("RSET_HOST_CONNECT");
+		host_connect_fail = getenv("RSET_HOST_CONNECT_FAIL");
 		label_exec_begin_msg = getenv("RSET_LABEL_EXEC_BEGIN");
 		label_exec_end_msg = getenv("RSET_LABEL_EXEC_END");
 		label_exec_error_msg = getenv("RSET_LABEL_EXEC_ERROR");
@@ -206,7 +208,7 @@ execute_remote(char *hostnames[], Label **route_labels, regex_t *label_reg) {
 				snprintf(socket_path, len, LOCAL_SOCKET_PATH, hostname);
 
 				if (start_connection(socket_path, hostname, route_labels[i], http_port, sshconfig_file) == -1) {
-					log_msg(host_disconnect_msg, hostname, "", 0);
+					log_msg(host_connect_fail, hostname, "", 0);
 					end_connection(socket_path, hostname, http_port);
 					free(socket_path);
 					socket_path = NULL;


### PR DESCRIPTION
Allow a formatted log message using `RSET_HOST_CONNECT_FAIL` indicating that the SSH connection or staging directory initialization failed.

Expect error messages from sh(1), ssh(1), and tar(1) as stderr is not redirected.