### PR TITLE
Add compat.h for testing framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.o
-/Makefile
+Makefile
 compat.c
 labelgrep
 miniquark

--- a/Makefile.bsd
+++ b/Makefile.bsd
@@ -82,6 +82,7 @@ clean:
 	make -C tests clean
 
 distclean:
+	rm -f tests/Makefile
 	rm -f Makefile
 
 .PHONY: all clean distclean install test uninstall

--- a/configure
+++ b/configure
@@ -33,6 +33,11 @@ copy_mk() {
 	echo "+ $cmd"; $cmd
 }
 
+copy_tests_mk() {
+	cmd="cp tests/Makefile.$1 tests/Makefile"
+	echo "+ $cmd"; $cmd
+}
+
 while [ $# -gt 0 ]; do
 	case $1 in
 		-h) usage ;;
@@ -43,12 +48,17 @@ done
 
 case "${TARGET_OS:-`uname`}" in
 	Darwin)
-		copy_mk macos;
+		copy_mk macos
+		copy_tests_mk bsd
 		;;
 	Linux)
 		test_libc_features && copy_mk linux || copy_mk linux-compat
+		copy_tests_mk linux
 		;;
 	*)
 		copy_mk bsd
+		copy_tests_mk bsd
 		;;
 esac
+
+# vim:noexpandtab:syntax=sh:ts=4

--- a/tests/Makefile.bsd
+++ b/tests/Makefile.bsd
@@ -18,7 +18,7 @@ rset.o: ${RSET_LIBS}
 	${LD} -r ${RSET_LIBS} -o $@ ${LDFLAGS}
 
 .c: rset.o ${RSET_LIBS}
-	${CC} -I.. ${CFLAGS} $< rset.o -o $@ ${LDFLAGS}
+	${CC} -I.. ${CFLAGS} ${CPPFLAGS} $< rset.o -o $@ ${LDFLAGS}
 
 test: ${OBJS}
 	@${RUBY} test_renv.rb

--- a/tests/Makefile.linux
+++ b/tests/Makefile.linux
@@ -1,0 +1,3 @@
+CPPFLAGS += -D_GNU_SOURCE -D_LINUX_PORT
+
+include Makefile.bsd

--- a/tests/parser.c
+++ b/tests/parser.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "missing/compat.h"
 #include "rutils.h"
 
 /* forwards */


### PR DESCRIPTION
Make sure parser.c is compiled on Linux without warnings by configuring tests Makefile  based on the OS type.