### PR TITLE
Log error status when SSH terminates during script execution

### DIFF
--- a/rset.1
+++ b/rset.1
@@ -13,7 +13,7 @@
 .\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 .\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd February 15, 2024
+.Dd February 20, 2024
 .Dt RSET 1
 .Os
 .Sh NAME
@@ -39,9 +39,9 @@ accepts one or more hostnames which match the labels in
 The arguments are as follows:
 .Bl -tag -width Ds
 .It Fl e
-Stop executing if an error is encountered within a label.
+Exit immediately if any label returns non-zero exit status.
 .It Fl n
-Do not connect to remote hosts. May be comed with
+Do not connect to remote hosts. May be combined with
 .Fl x
 to highlight label names that match.
 Special text defined between { and } is still executed locally.
@@ -74,7 +74,7 @@ By default only labels beginning with [0-9a-z] are evaluated.
 .Sh ENVIRONMENT
 Status messages for each stage of execution may be customized by setting
 .Ev RSET_HOST_CONNECT ,
-.Ev RSET_HOST_CONNECT_FAIL ,
+.Ev RSET_HOST_CONNECT_ERROR ,
 .Ev RSET_LABEL_EXEC_BEGIN ,
 .Ev RSET_LABEL_EXEC_END ,
 .Ev RSET_LABEL_EXEC_ERROR ,


### PR DESCRIPTION
Log error status when SSH terminates during script execution

* log EXEC_ERROR if environment file cannot be updated
* log EXEC_ERROR if ssh(1) returns exit code 255
* log EXEC_ERROR if sh(1) returns exit code 127
* Set log format variable '%e' for connection failures
* Rename RSET_HOST_CONNECT_FAIL to RSET_HOST_CONNECT_ERROR as both error messages may indicate a problem with remote connectivity
