### PR TITLE
Use 'set -a' to export variables

### DIFF
--- a/execute.c
+++ b/execute.c
@@ -396,8 +396,8 @@ ssh_command_pipe(char *host_name, char *socket_path, Label *host_label, int http
 	apply_default(op.execute_with, host_label->options.execute_with, EXECUTE_WITH);
 	apply_default(op.interpreter, host_label->options.interpreter, INTERPRETER);
 
-	snprintf(cmd, sizeof(cmd), "%s sh -a -c \""
-	    "cd %s; . ./final.env; . ./local.env; "
+	snprintf(cmd, sizeof(cmd), "%s sh -c \""
+	    "cd %s; set -a; . ./final.env; . ./local.env; "
 	    "SD='%s' INSTALL_URL='" INSTALL_URL "'; exec %s\"",
 	    op.execute_with, stagedir(http_port), stagedir(http_port), op.interpreter);
 
@@ -437,8 +437,8 @@ ssh_command_tty(char *host_name, char *socket_path, Label *host_label, int http_
 	apply_default(op.execute_with, host_label->options.execute_with, EXECUTE_WITH);
 	apply_default(op.environment_file, host_label->options.environment_file, ENVIRONMENT_FILE);
 
-	snprintf(cmd, sizeof(cmd), "%s sh -a -c \""
-	    "cd %s; . ./final.env; . ./local.env; "
+	snprintf(cmd, sizeof(cmd), "%s sh -c \""
+	    "cd %s; set -a; . ./final.env; . ./local.env; "
 	    "SD='%s' INSTALL_URL='" INSTALL_URL "'; exec %s %s/_script\"",
 	    op.execute_with, stagedir(http_port), stagedir(http_port), op.interpreter, stagedir(http_port));
 

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -151,7 +151,7 @@ try 'Execute commands over ssh using a pipe' do
   eq out, <<~RESULT
     renv /dev/null /tmp/rset_env_XXXXXX
     ssh -q -S /tmp/test_rset_socket 10.0.0.98 'cat > /tmp/rset_staging_6000/final.env; touch /tmp/rset_staging_6000/local.env'
-    ssh -T -S /tmp/test_rset_socket 10.0.0.98 ' sh -a -c "cd /tmp/rset_staging_6000; . ./final.env; . ./local.env; SD='/tmp/rset_staging_6000' INSTALL_URL='http://127.0.0.1:6000'; exec /bin/sh"'
+    ssh -T -S /tmp/test_rset_socket 10.0.0.98 ' sh -c "cd /tmp/rset_staging_6000; set -a; . ./final.env; . ./local.env; SD='/tmp/rset_staging_6000' INSTALL_URL='http://127.0.0.1:6000'; exec /bin/sh"'
   RESULT
 end
 
@@ -164,7 +164,7 @@ try 'Execute commands over ssh using a tty' do
     renv /dev/null /tmp/rset_env_XXXXXX
     ssh -q -S /tmp/test_rset_socket 10.0.0.99 'cat > /tmp/rset_staging_6000/final.env; touch /tmp/rset_staging_6000/local.env'
     ssh -T -S /tmp/test_rset_socket 10.0.0.99 'cat > /tmp/rset_staging_6000/_script'
-    ssh -t -S /tmp/test_rset_socket 10.0.0.99 ' sh -a -c "cd /tmp/rset_staging_6000; . ./final.env; . ./local.env; SD='/tmp/rset_staging_6000' INSTALL_URL='http://127.0.0.1:6000'; exec /bin/sh /tmp/rset_staging_6000/_script"'
+    ssh -t -S /tmp/test_rset_socket 10.0.0.99 ' sh -c "cd /tmp/rset_staging_6000; set -a; . ./final.env; . ./local.env; SD='/tmp/rset_staging_6000' INSTALL_URL='http://127.0.0.1:6000'; exec /bin/sh /tmp/rset_staging_6000/_script"'
   RESULT
 end
 


### PR DESCRIPTION
`sh -a` exports all of the variables set during shell startup.  For Bash this may include `POSIXLY_CORRECT` which causes the shell to use a restricted feature set even if `interpreter=/bin/bash`.