### PR TITLE
Add archive and restore options

### DIFF
--- a/config.h
+++ b/config.h
@@ -12,6 +12,7 @@
 #define INSTALL_PORT 6000
 #define ROUTES_FILE "routes.pln"
 #define REPLICATED_DIRECTORY "_rutils"
+#define ARCHIVE_DIRECTORY "_archive"
 #define PUBLIC_DIRECTORY "_sources"
 #define DEFAULT_LABEL_PATTERN "^[0-9a-z]"
 

--- a/execute.h
+++ b/execute.h
@@ -33,6 +33,7 @@ int start_connection(char *socket_path, char *host_name, Label *route_label, int
 int update_environment_file(char *host_name, char *socket_path, Label *host_label, int http_port, const char *env_override);
 int ssh_command_pipe(char *host_name, char *socket_path, Label *host_label, int http_port, const char *env_override);
 int ssh_command_tty(char *host_name, char *socket_path, Label *host_label, int http_port, const char *env_override);
+int scp_archive(char *host_name, char *socket_path, Label *host_label, int http_port, int direction);
 void end_connection(char *socket_path, char *host_name, int http_port);
 
 void apply_default(char *option, const char *user_option, const char *default_option);

--- a/input.c
+++ b/input.c
@@ -207,7 +207,6 @@ alloc_labels() {
  */
 void
 read_host_labels(Label *route_label) {
-	int j;
 	char *line, *next_line;
 	char *content;
 
@@ -229,16 +228,6 @@ read_host_labels(Label *route_label) {
 		parse_pln();
 		fclose(yyin);
 		line = next_line+1;
-
-		/* unsupported options */
-		for (j=0; host_labels[j]; j++) {
-			if (*host_labels[j]->export_paths != NULL) {
-				fprintf(stderr, "%s: label validation error: '%s'\n"
-				    "      path export lists are only supported route files\n",
-				    yyfn, host_labels[j]->name);
-				exit(1);
-			}
-		}
 	}
 	free(content);
 }

--- a/rset.1
+++ b/rset.1
@@ -21,7 +21,7 @@
 .Nd remote staging and execution tool
 .Sh SYNOPSIS
 .Nm rset
-.Op Fl entv
+.Op Fl AenRtv
 .Op Fl E Ar environment
 .Op Fl F Ar sshconfig_file
 .Op Fl f Ar routes_file
@@ -47,6 +47,12 @@ accepts one or more hostnames which match the labels in
 .Pp
 The arguments are as follows:
 .Bl -tag -width Ds
+.It Fl A
+Download files listed in label export paths to the local
+.Pa _archive
+directory in the format
+.Sq hostname basename(filename) .
+Absolute paths are permitted, or paths relative to the staging directory.
 .It Fl e
 Exit immediately if any label returns non-zero exit status.
 .It Fl n
@@ -55,6 +61,12 @@ May be combined with
 .Fl x
 to highlight label names that match.
 Special text defined between { and } is still executed locally.
+.It Fl R
+Send files listed in label export paths from the local
+.Pa _archive
+directory.
+This is the reverse of
+.Fl A .
 .It Fl t
 Allow TTY input by copying the content of each label to the remote host instead
 of opening a pipe to the interpreter.

--- a/rutils.c
+++ b/rutils.c
@@ -58,6 +58,17 @@ xdirname(const char *path) {
 }
 
 /*
+ * Mimic basename(3) on OpenBSD which does not modify it's input
+ */
+char *
+xbasename(const char *path) {
+	static char dname[PATH_MAX];
+
+	strlcpy(dname, path, sizeof(dname));
+	return basename(dname);
+}
+
+/*
  * create_dir - ensure a directory exists
  * install_if_new - ensure a file is up to date
  */

--- a/rutils.h
+++ b/rutils.h
@@ -23,6 +23,7 @@
 unsigned generate_session_id();
 unsigned current_session_id();
 char *xdirname(const char *path);
+char *xbasename(const char *path);
 int create_dir(const char *dir);
 void install_if_new(const char *src, const char *dst);
 void hl_range(const char *s, const char *color, unsigned so, unsigned eo);

--- a/tests/ssh_command.c
+++ b/tests/ssh_command.c
@@ -14,8 +14,10 @@ void usage();
 void usage() {
 	fprintf(stderr, "usage:\n"
 	    "  ./ssh_command S hostname [export_paths]\n" /* Start session */
-	    "  ./ssh_command P hostname [env_override]\n" /* Remote Execution over a pipe */
+	    "  ./ssh_command P hostname [env_override]\n" /* Remote execution over a pipe */
 	    "  ./ssh_command T hostname [env_override]\n" /* Remote execution with TTY */
+	    "  ./ssh_command A hostname [export_paths]\n" /* Archive files */
+	    "  ./ssh_command R hostname [export_paths]\n" /* Resore files */
 	    "  ./ssh_command E hostname\n");              /* End session */
 	exit(1);
 }
@@ -52,6 +54,16 @@ int main(int argc, char *argv[])
 		if (argc == 4)
 			env_override = argv[3];
 		ssh_command_tty(host_name, socket_path, &host_label, http_port, env_override);
+		break;
+	case 'A':
+		if (argc == 4)
+			str_to_array(host_label.export_paths, strdup(argv[3]), PLN_MAX_PATHS, " ");
+		scp_archive(host_name, socket_path, &host_label, http_port, 1);
+		break;
+	case 'R':
+		if (argc == 4)
+			str_to_array(host_label.export_paths, strdup(argv[3]), PLN_MAX_PATHS, " ");
+		scp_archive(host_name, socket_path, &host_label, http_port, 0);
 		break;
 	case 'E':
 		end_connection(socket_path, host_name, http_port);

--- a/tests/stubs/scp
+++ b/tests/stubs/scp
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# echo command line, quoting arguments with spaces
+/usr/bin/awk 'BEGIN {
+	printf "scp"
+	for (i=1; i<ARGC; i++) {
+		if (index(ARGV[i], " "))
+			printf " \047" ARGV[i] "\047"
+		else
+			printf " " ARGV[i]
+	}
+	printf "\n" }' "$@"


### PR DESCRIPTION
Transfer files using scp(1). The purpose of this is to allow easy backup of important files from a remote host that should be installed after a rebuild.

Previously export paths were only allowed in the routes file. Now they may be added to other labels, where they signify an artifact that may be archived or restored:

```
_download: certs.tar
    tar -cpf $SD/certs.tar \
        /etc/ssl/private \
        /etc/ssl/sidecomment.io.*

_upload: certs.tar
    tar -C / -xpf $SD/certs.tar
```

In this examples the labels names begin with a non-alphanumeric character so they are not executed by default.

```
rset -A -x _download svc1.sidecomment.io
```

Errors reported by scp(1) are not fatal unless `-e` is specified.

Parallel operation is not supported yet, but this can be be accomplished by extending custom logging.