### PR TITLE
Add begin= and end= options

### DIFF
--- a/execute.c
+++ b/execute.c
@@ -501,6 +501,23 @@ end_connection(char *socket_path, char *host_name, int http_port) {
 		warn("exec ssh -O exit");
 }
 
+/* local execution */
+
+int
+local_exec(Label *host_label, char *cmd) {
+	char *argv[4];
+	size_t len;
+	Options op;
+	int ret = 0;
+
+	if ((cmd) && (len = strlen(cmd)) > 0) {
+		apply_default(op.local_interpreter, host_label->options.interpreter, INTERPRETER);
+		(void) append(argv, 0, op.local_interpreter, NULL);
+		ret = cmd_pipe_stdin(argv, cmd, len);
+	}
+	return ret;
+}
+
 /* internal utility functions */
 
 void

--- a/execute.h
+++ b/execute.h
@@ -35,5 +35,6 @@ int ssh_command_pipe(char *host_name, char *socket_path, Label *host_label, int 
 int ssh_command_tty(char *host_name, char *socket_path, Label *host_label, int http_port, const char *env_override);
 int scp_archive(char *host_name, char *socket_path, Label *host_label, int http_port, int direction);
 void end_connection(char *socket_path, char *host_name, int http_port);
+int local_exec(Label *host_label, char *cmd);
 
 void apply_default(char *option, const char *user_option, const char *default_option);

--- a/input.c
+++ b/input.c
@@ -309,6 +309,10 @@ read_label(char *line, Label *label) {
 
 	memcpy(&label->options, &current_options, sizeof(current_options));
 
+	/* options not inherited */
+	current_options.begin = 0;
+	current_options.end = 0;
+
 	label->content_size = 0;
 	label->labels = 0;
 }
@@ -341,6 +345,13 @@ read_option(char *text, Options *op) {
 			free(content);
 		}
 	}
+	else if (strcmp(k, "begin") == 0) {
+		op->begin = strndup(v, strlen(v));
+	}
+	else if (strcmp(k, "end") == 0) {
+		op->end = strndup(v, strlen(v));
+	}
+
 	else {
 		fprintf(stderr, "%s: unknown option '%s=%s'\n", yyfn, k, v);
 		exit(1);

--- a/input.h
+++ b/input.h
@@ -34,6 +34,9 @@ typedef struct {
 	char local_interpreter[PLN_OPTION_SIZE];
 	char environment[PLN_OPTION_SIZE];
 	char environment_file[PLN_OPTION_SIZE];
+	/* not inherited */
+	char *begin;
+	char *end;
 } Options;
 
 typedef struct Label {

--- a/rset.1
+++ b/rset.1
@@ -197,6 +197,16 @@ Command for elevating privileges, such as
 .Xr doas 1
 and
 .Xr sudo 8 .
+.Sh SINGLE USE OPTIONS
+The following are effective only for the subsequent label:
+.Ss \&begin=
+Execute a script using the
+.Sq local_interpreter
+before the label is executed on the remote lost.
+.Ss \&end=
+Execute a script using the
+.Sq local_interpreter
+after the label is executed on the remote host.
 .Sh SEE ALSO
 .Xr miniquark 1 ,
 .Xr rinstall 1 ,

--- a/tests/expected/recursive.json
+++ b/tests/expected/recursive.json
@@ -11,7 +11,9 @@
           "environment_file": "",
           "interpreter": "",
           "local_interpreter": "",
-          "execute_with": "doas"
+          "execute_with": "doas",
+          "begin": "",
+          "end": ""
         }
       },
       {
@@ -22,7 +24,9 @@
           "environment_file": "",
           "interpreter": "",
           "local_interpreter": "/bin/sh -e",
-          "execute_with": "doas"
+          "execute_with": "doas",
+          "begin": "[ -f .lock ] && false || touch .lock",
+          "end": "rm .lock"
         }
       },
       {
@@ -33,7 +37,9 @@
           "environment_file": "",
           "interpreter": "/bin/ksh -x",
           "local_interpreter": "/bin/sh -e",
-          "execute_with": "doas"
+          "execute_with": "doas",
+          "begin": "",
+          "end": ""
         }
       }
     ]
@@ -50,7 +56,9 @@
           "environment_file": "",
           "interpreter": "",
           "local_interpreter": "",
-          "execute_with": "doas"
+          "execute_with": "doas",
+          "begin": "",
+          "end": ""
         }
       }
     ]

--- a/tests/input/t460s.pln
+++ b/tests/input/t460s.pln
@@ -3,6 +3,8 @@
 local_interpreter=/bin/sh -e
 environment=WORKDIR="$PWD" http_proxy="http://192.168.3.2:3128"
 
+begin=[ -f .lock ] && false || touch .lock
+end=rm .lock
 common packages:
 {
 	echo "MIRROR=http://cdn.openbsd.org/pub/OpenBSD"

--- a/tests/parser.c
+++ b/tests/parser.c
@@ -11,6 +11,7 @@
 void indent(int level);
 char *quote(char *str);
 char * array_to_json(char *argv[]);
+char * str_or_empty(char *s);
 
 /* globals */
 Label **route_labels;    /* parent */
@@ -51,7 +52,9 @@ int main(int argc, char *argv[]) {
 			indent(5); printf("\"environment_file\": \"%s\",\n", host_labels[j]->options.environment_file);
 			indent(5); printf("\"interpreter\": \"%s\",\n", host_labels[j]->options.interpreter);
 			indent(5); printf("\"local_interpreter\": \"%s\",\n", host_labels[j]->options.local_interpreter);
-			indent(5); printf("\"execute_with\": \"%s\"\n", host_labels[j]->options.execute_with);
+			indent(5); printf("\"execute_with\": \"%s\",\n", host_labels[j]->options.execute_with);
+			indent(5); printf("\"begin\": \"%s\",\n", str_or_empty(host_labels[j]->options.begin));
+			indent(5); printf("\"end\": \"%s\"\n", str_or_empty(host_labels[j]->options.end));
 			indent(4); printf("}\n");
 			indent(3); printf("}");
 		}
@@ -93,6 +96,13 @@ array_to_json(char *argv[]) {
 	count += strlcpy(p+count, "]", size-count);
 	outputstring[count] = '\0';
 	return outputstring;
+}
+
+char *
+str_or_empty(char *s) {
+	if (s)
+		return s;
+	return "";
 }
 
 char *

--- a/tests/test_labelgrep.rb
+++ b/tests/test_labelgrep.rb
@@ -32,9 +32,9 @@ try 'Scan multiple files with more than one label' do
   eq err, ''
   expected = <<~OUTPUT
     input/t460s.pln ([36mcommon packages[0m)
-    [33m10[0m	[4mpkg_add [0mrsync-- ruby%3.2
+    [33m12[0m	[4mpkg_add [0mrsync-- ruby%3.2
     input/t460s.pln ([36mdesktop[0m)
-    [33m22[0m	[4mpkg_add [0mhermit-font vim--gtk2
+    [33m24[0m	[4mpkg_add [0mhermit-font vim--gtk2
   OUTPUT
   eq out, expected
   eq status.success?, true
@@ -46,8 +46,8 @@ try 'Find more than one match per label' do
   eq err, ''
   expected = <<~OUTPUT
     input/t460s.pln ([36mcommon packages[0m)
-    [33m11[0m	echo "inet 172.16.0.1/16" > [4m/etc/hostname[0m.vether0
-    [33m12[0m	echo "add vether0" > [4m/etc/hostname[0m.bridge0
+    [33m13[0m	echo "inet 172.16.0.1/16" > [4m/etc/hostname[0m.vether0
+    [33m14[0m	echo "add vether0" > [4m/etc/hostname[0m.bridge0
   OUTPUT
   eq out, expected
   eq status.success?, true


### PR DESCRIPTION
Allows label execution to be bracketed with local commands before and after remote execution.  Unlike other options, these are "single use" and are not inherited.

One use for this feature is to start and stop transitory network services.  Ports may be mapped for communication in `~/.ssh/config`

```
Host 192.168.2.2
    RemoteForward 4444 localhost:4444
```