### PR TITLE
Ensure top-level directory permissions are not world-readable

### DIFF
--- a/rset.c
+++ b/rset.c
@@ -120,6 +120,8 @@ main(int argc, char *argv[]) {
 		err(1, "unable to open %s", routes_file);
 	(void) close(fd);
 
+	check_permissions(routes_realpath);
+
 	if (!dryrun_opt) {
 		/* require ssh-agent */
 		if (verify_ssh_agent() != 0) {

--- a/rutils.c
+++ b/rutils.c
@@ -33,6 +33,10 @@
 
 unsigned session_id;
 
+/* globals */
+
+int dir_mode = 0700;
+
 /*
  * Update global session ID before starting a new SSH session
  */
@@ -71,17 +75,29 @@ xbasename(const char *path) {
 }
 
 /*
+ * check_permissions - verify and memorize top-level directory permissions
+ */
+
+void
+check_permissions(const char *dir) {
+	struct stat stat_buf;
+
+	stat(dir, &stat_buf);
+	if (stat_buf.st_mode & (S_IWGRP | S_IRWXO))
+		errx(1, "invalid permissions for %s: mode must be u=rwx (0700) or u=rwx,g=rx (0750)", dir);
+	dir_mode = stat_buf.st_mode;
+}
+
+/*
  * create_dir - ensure a directory exists
  * install_if_new - ensure a file is up to date
  */
 int
 create_dir(const char *dir) {
-	mode_t dir_mode;
 	struct stat dst_sb;
 
 	if (stat(dir, &dst_sb) == -1) {
 		printf("rset: initialized directory '%s'\n", dir);
-		dir_mode = 0750;
 		(void) mkdir(dir, dir_mode);
 		return 1;
 	}

--- a/rutils.h
+++ b/rutils.h
@@ -24,6 +24,7 @@ unsigned generate_session_id();
 unsigned current_session_id();
 char *xdirname(const char *);
 char *xbasename(const char *);
+void check_permissions(const char *);
 int create_dir(const char *);
 void install_if_new(const char *, const char *);
 void hl_range(const char *, const char *, unsigned, unsigned);


### PR DESCRIPTION
This check is also used to set the directory mode to `0700` or `0750` when creating other directories (`_rutils`, `_sources`, `_sources`).