### PR TITLE
Update MANPREFIX for FreeBSD

### DIFF
--- a/Makefile.freebsd
+++ b/Makefile.freebsd
@@ -1,0 +1,3 @@
+MANPREFIX ?= ${PREFIX}/share/man
+
+include Makefile.bsd

--- a/configure
+++ b/configure
@@ -51,6 +51,10 @@ case "${TARGET_OS:-`uname`}" in
 		copy_mk macos
 		copy_tests_mk bsd
 		;;
+	FreeBSD)
+		copy_mk freebsd
+		copy_tests_mk bsd
+		;;
 	Linux)
 		test_libc_features && copy_mk linux || copy_mk linux-compat
 		copy_tests_mk linux


### PR DESCRIPTION
share/man became a valid path for manpage since Jan 2020. And we converted the whole ports tree to share/man around last March.