### PR TITLE
Replace inline copyright with synopsis

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,22 +15,13 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-Source code for `miniquark` is based on `quark` under the following license:
+Source code for `miniquark` is based on `quark` under the ISC-style
+license, to the following copyright holders:
 
-ISC-License
-
-Copyright 2016-2020 Laslo Hunhold <dev@frign.de>
-
-Copyright 2004 Ted Unangst <tedu@openbsd.org>
-Copyright 2004 Todd C. Miller <Todd.Miller@courtesan.com>
-Copyright 2008 Otto Moerbeek <otto@drijf.net>
-Copyright 2017-2018 Hiltjo Posthuma <hiltjo@codemadness.org>
-Copyright 2017-2018 Quentin Rameau <quinq@fifth.space>
-Copyright 2018 Josuah Demangeon <mail@josuah.net>
-Copyright 2018 Dominik Schmidt <domischmidt@swissonline.ch>
-Copyright 2018 Aaron Burrow <burrows@charstarstar.com>
-Copyright 2020 Nihal Jere <nihal@nihaljere.xyz>
-Copyright 2020 Rainer Holzner <rholzner@web.de>
+Laslo Hunhold <dev@frign.de>
+Hiltjo Posthuma <hiltjo@codemadness.org>
+Quentin Rameau <quinq@fifth.space>
+Anselm R Garbe <anselm@garbe.us>
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/execute.c
+++ b/execute.c
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * execute.c
+ * SSH session management and function for execution
  */
 
 #include <sys/socket.h>

--- a/execute.h
+++ b/execute.h
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * execute.c
+ * SSH session management and function for execution
  */
 
 #include "input.h"

--- a/http.c
+++ b/http.c
@@ -1,4 +1,7 @@
-/* miniquark: see LICENSE file for copyright and license details. */
+/*
+ * http.c
+ * HTTP request handling for miniquark
+ */
 
 #include <errno.h>
 #include <stdio.h>

--- a/http.h
+++ b/http.h
@@ -1,4 +1,7 @@
-/* miniquark: see LICENSE file for copyright and license details. */
+/*
+ * http.h
+ * HTTP request handling for miniquark
+ */
 
 #include <sys/stat.h>
 

--- a/input.c
+++ b/input.c
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * input.c
+ * Parse progressive label notation
  */
 
 #include <err.h>

--- a/input.h
+++ b/input.h
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * input.h
+ * Parse progressive label notation
  */
 
 #include <limits.h>

--- a/labelgrep.1
+++ b/labelgrep.1
@@ -1,18 +1,3 @@
-.\"
-.\" Copyright (c) 2019 Eric Radman <ericshane@eradman.com>
-.\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
-.\"
-.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-.\"
 .Dd January 17, 2026
 .Dt LABELGREP 1
 .Os
@@ -45,6 +30,10 @@ Show all routes that include the wordpress configuration
 .Sh SEE ALSO
 .Xr rset 1 ,
 .Xr re_format 7
+.Sh HISTORY
+The
+.Nm
+utility was introduced in rset 1.2
 .Sh CAVEATS
 .Nm
 does not attempt to validate the format of each file.

--- a/labelgrep.awk
+++ b/labelgrep.awk
@@ -1,4 +1,5 @@
 #!/usr/bin/awk -f
+# labelgrep
 # A pattern searcher for the pln(5) format used by rset(1)
 # Displays the source file, label name, and contents that match
 

--- a/miniquark.1
+++ b/miniquark.1
@@ -40,6 +40,4 @@ Used for log messages.
 .Nm
 was based on
 .Lk https://git.suckless.org/quark
-and bundled with
-.Xr rset 1
-in July 2020.
+and bundled with rset 1.6

--- a/miniquark.c
+++ b/miniquark.c
@@ -1,4 +1,7 @@
-/* miniquark: see LICENSE file for copyright and license details. */
+/*
+ * miniquark.c
+ * a minimal web server for retrieving files
+ */
 
 #include <sys/socket.h>
 #include <sys/wait.h>

--- a/missing/arc4random.c
+++ b/missing/arc4random.c
@@ -1,3 +1,8 @@
+/*
+ * arc4random.c
+ * Emulate interface to random number generator
+ */
+
 #include <inttypes.h>
 #include <sys/random.h>
 

--- a/missing/setproctitle.c
+++ b/missing/setproctitle.c
@@ -1,3 +1,8 @@
+/*
+ * setproctitle.c
+ * No-op on Linux
+ */
+
 void
 setproctitle(const char *fmt, ...) {
 	return;

--- a/pln.5
+++ b/pln.5
@@ -1,18 +1,3 @@
-.\"
-.\" Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
-.\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
-.\"
-.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-.\"
 .Dd January 17, 2026
 .Dt PLN 5
 .Os
@@ -83,3 +68,5 @@ Comments begin with a hash
 character, and can only be used the beginning of a line.
 .Sh SEE ALSO
 .Xr labelgrep 1
+.Sh AUTHORS
+.An Eric Radman Aq Mt ericshane@eradman.com

--- a/renv.1
+++ b/renv.1
@@ -1,18 +1,3 @@
-.\"
-.\" Copyright (c) 2023 Eric Radman <ericshane@eradman.com>
-.\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
-.\"
-.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-.\"
 .Dd January 17, 2026
 .Dt RENV 1
 .Os
@@ -66,8 +51,10 @@ Print environment variables in a normalized format
 Save the status code of the last command
 .Pp
 .Dl $ renv LAST_EXITSTATUS="$?"
-.Sh SEE ALSO
-.Xr rset 1
+.Sh HISTORY
+The
+.Nm
+utility was introduced in rset 2.8
 .Sh CAVEATS
 Tabs and multiple spaces are converted to into a single space.
 There is no provision for embedding literal double-quotes.

--- a/renv.awk
+++ b/renv.awk
@@ -1,4 +1,5 @@
 #!/usr/bin/awk -f
+# renv
 # Set up remote environment for rset(1)
 # Print only lines that match the format [name="value" ...]
 

--- a/rexec-summary.awk
+++ b/rexec-summary.awk
@@ -1,6 +1,7 @@
 #!/usr/bin/awk -f
+# rexec-summary
 # A log parser for rset(1) parallel workers
-# Displays a summary of each session
+# display a summary of each session
 
 # fields:
 #   $1  session ID

--- a/rinstall.1
+++ b/rinstall.1
@@ -1,18 +1,3 @@
-.\"
-.\" Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
-.\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
-.\"
-.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-.\"
 .Dd January 17, 2026
 .Dt RINSTALL 1
 .Os
@@ -123,3 +108,7 @@ under tools/sys/ if it's not already there and it's not available at
 $INSTALL_URL/tools/sys/sometool.tgz
 .Pp
 .Dl $SD/rinstall -a https://example.org/files/tool.tar.gz tools/sys/sometool.tgz
+.Sh HISTORY
+The
+.Nm
+utility was introduced in rset 0.1

--- a/rinstall.sh
+++ b/rinstall.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# rinstall
 # A helper utility for rset(1)
 # Install files from the local staging area or a remote URL
 

--- a/rset.1
+++ b/rset.1
@@ -1,18 +1,3 @@
-.\"
-.\" Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
-.\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
-.\"
-.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-.\"
 .Dd January 17, 2026
 .Dt RSET 1
 .Os
@@ -215,3 +200,5 @@ after the label is executed on the remote host.
 .Xr rsub 1 ,
 .Xr ssh_config 5 ,
 .Xr re_format 7
+.Sh AUTHORS
+.An Eric Radman Aq Mt ericshane@eradman.com

--- a/rset.c
+++ b/rset.c
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * rset.c
+ * Configure systems using any scripting language
  */
 
 #include <sys/wait.h>

--- a/rsub.1
+++ b/rsub.1
@@ -1,18 +1,3 @@
-.\"
-.\" Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
-.\"
-.\" Permission to use, copy, modify, and distribute this software for any
-.\" purpose with or without fee is hereby granted, provided that the above
-.\" copyright notice and this permission notice appear in all copies.
-.\"
-.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-.\"
 .Dd January 17, 2026
 .Dt RSUB 1
 .Os
@@ -94,3 +79,7 @@ $SD/rsub /etc/fstab <<-CONF
 .Sh SEE ALSO
 .Xr awk 1 ,
 .Xr rinstall 1
+.Sh HISTORY
+The
+.Nm
+utility was introduced in rset 0.7

--- a/rsub.sh
+++ b/rsub.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
+# rsub
 # A helper utility for rset(1)
 # Substitute lines in a file or append if not found
 
 set_defaults() {
-	ret=1     # global exit statu
+	ret=1     # global exit status
 	append=1  # set to 0 to append text in line-replace mode
 	line_regex=""
 	line_text=""

--- a/rutils.c
+++ b/rutils.c
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * rutils.c
+ * Utility functions for rset
  */
 
 #include <sys/stat.h>

--- a/rutils.h
+++ b/rutils.h
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * rutils.h
+ * Utility functions for rset
  */
 
 #include <inttypes.h>

--- a/sock.c
+++ b/sock.c
@@ -1,4 +1,7 @@
-/* miniquark: see LICENSE file for copyright and license details. */
+/*
+ * sock.c
+ * IP/socket functions for miniquark
+ */
 
 #include <sys/socket.h>
 #include <sys/time.h>

--- a/sock.h
+++ b/sock.h
@@ -1,4 +1,7 @@
-/* miniquark: see LICENSE file for copyright and license details. */
+/*
+ * sock.c
+ * IP/socket functions for miniquark
+ */
 
 #define LISTEN_MAX 4
 

--- a/worker.c
+++ b/worker.c
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2024 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * worker.c
+ * Functions for parallel execution in rset
  */
 
 #include <sys/wait.h>

--- a/worker.h
+++ b/worker.h
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2024 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * worker.h
+ * Functions for parallel execution in rset
  */
 
 #include "input.h"

--- a/xlibc.c
+++ b/xlibc.c
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * xlibc.c
+ * Standard libc function augmented with behavior expected by rset
  */
 
 #include <err.h>

--- a/xlibc.h
+++ b/xlibc.h
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2018 Eric Radman <ericshane@eradman.com>
- *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * xlibc.c
+ * Standard libc function augmented with behavior expected by rset
  */
 
 #include <sys/stat.h>


### PR DESCRIPTION
* Rely on LICENSE file
* Use synopsis at the top of source files
* Add AUTHORS section to rset(1) and pln(5)
* Add HISTORY section to other man pages
* Leave inline Copyright for strtonum.c