### PR TITLE
rinstall: create directories using the same owner as $SD

### DIFF
--- a/rinstall.sh
+++ b/rinstall.sh
@@ -111,6 +111,7 @@ set_source_target_vars() {
 			>&2 echo "rinstall: could not create a relative path: $SD/$src_rel_path"
 			exit 1
 		}
+		fix_permissions
 
 		if [ "$src_rel_path" = "." ]; then
 			target="$SD/$(basename "$source")"
@@ -143,10 +144,13 @@ download_source() {
 	fi
 
 	# Reconstruct the source's relative path
-	[ -d "$SD/$src_path" ] || mkdir -p "$SD/$src_path" || {
-		>&2 echo "rinstall: could not create a relative path: $SD/$src_path"
-		exit 1
-	}
+	if [ ! -d "$SD/$src_path" ]; then
+		mkdir -p "$SD/$src_path" || {
+			>&2 echo "rinstall: could not create a relative path: $SD/$src_path"
+			exit 1
+		}
+		fix_permissions
+	fi
 
 	fetch_file "$INSTALL_URL/$source"
 	if [ $? -ne 0 ]; then
@@ -253,6 +257,11 @@ check_absolute_path() {
 		*)  return 1
 			;;
 	esac
+}
+
+fix_permissions() {
+	uid=$(stat -f '%u' $SD 2> /dev/null) || uid=$(stat -c '%u' $SD)
+	find $SD -type d -not -user $uid -exec chown $uid {} ';'
 }
 
 main "$@"

--- a/tests/test_rinstall.rb
+++ b/tests/test_rinstall.rb
@@ -38,6 +38,8 @@ at_exit do
   Process.kill(15, @wwwserver)
 end
 
+ENV['PATH'] = "#{Dir.pwd}/trace:#{ENV.fetch('PATH', nil)}"
+
 # wait for web server to initialize
 sleep 0.1
 
@@ -66,14 +68,17 @@ puts "\e[32m---\e[39m"
 # Functional tests
 
 try 'Install a file from a remote URL to the staging area' do
-  FileUtils.mkdir_p "#{@wwwtmp}/x/y"
+  FileUtils.mkdir_p "#{@wwwtmp}/x/a"
   fn = "test_#{@tests}.txt"
   dst = "#{@systmp}/#{fn}"
-  src = "#{@wwwtmp}/x/y/#{fn}"
+  src = "#{@wwwtmp}/x/a/#{fn}"
   File.write(src, '123')
-  cmd = "INSTALL_URL=#{@install_url} #{Dir.pwd}/../rinstall -m 644 x/y/#{fn} #{dst}"
+  cmd = "INSTALL_URL=#{@install_url} #{Dir.pwd}/../rinstall -m 644 x/a/#{fn} #{dst}"
   out, err, status = Open3.capture3(cmd, chdir: @systmp)
-  eq err, ''
+  eq err.gsub('\'', ''), <<~RESULT
+    + /bin/mkdir -p #{@systmp}/x/a
+    + /usr/bin/find #{@systmp} -type d -not -user #{Process.uid} -exec chown #{Process.uid} {} ;
+  RESULT
   eq out.chomp, "rinstall: created #{dst}"
   eq status.success?, true
   eq '123', File.read(dst)
@@ -81,14 +86,17 @@ try 'Install a file from a remote URL to the staging area' do
 end
 
 try 'Stage the file by fetching over HTTP when no target is defined' do
-  FileUtils.mkdir_p "#{@wwwtmp}/x/y"
+  FileUtils.mkdir_p "#{@wwwtmp}/x/b"
   fn = "test_#{@tests}.txt"
-  dst = "#{@systmp}/x/y/#{fn}"
-  src = "#{@wwwtmp}/x/y/#{fn}"
+  dst = "#{@systmp}/x/b/#{fn}"
+  src = "#{@wwwtmp}/x/b/#{fn}"
   File.write(src, '123')
-  cmd = "INSTALL_URL=#{@install_url} #{Dir.pwd}/../rinstall x/y/#{fn}"
+  cmd = "INSTALL_URL=#{@install_url} #{Dir.pwd}/../rinstall x/b/#{fn}"
   out, err, status = Open3.capture3({ 'SD' => @systmp.to_s }, cmd, chdir: @systmp)
-  eq err, ''
+  eq err.gsub('\'', ''), <<~RESULT
+    + /bin/mkdir -p #{@systmp}/x/b
+    + /usr/bin/find #{@systmp} -type d -not -user #{Process.uid} -exec chown #{Process.uid} {} ;
+  RESULT
   eq out, "rinstall: fetched #{dst}\n"
   eq status.exitstatus, 0
   eq '123', File.read(dst)

--- a/tests/trace/find
+++ b/tests/trace/find
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -x
+/usr/bin/find "$@"

--- a/tests/trace/mkdir
+++ b/tests/trace/mkdir
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -x
+/bin/mkdir "$@"


### PR DESCRIPTION
Ensure directories created by root can be removed at the end of the session.

`install -d -o $uid` does not set the ownership of intermediate directories created; instead keep `mkdir -p` correct them using find(1).
