### PR TITLE
Expand host ranges by extending route list

### DIFF
--- a/input.c
+++ b/input.c
@@ -236,6 +236,44 @@ read_host_labels(Label *route_label) {
 }
 
 /*
+ * expand_route_labels - transform host ranges
+ */
+void
+expand_route_labels() {
+	int i, j;
+	int n_exp;
+	int n_routes, n_routes_ext;
+	char *host_range[MAX_LABELS];
+
+	for (n_routes = 0; route_labels[n_routes]; n_routes++)
+		;
+
+	n_routes_ext = n_routes;
+	for (i = 0; i < n_routes; i++) {
+		n_exp = expand_numeric_range(host_range, route_labels[i]->name);
+		if ((n_exp > 0) && (route_labels[i]->n_aliases > 1))
+			errx(1, "'%s' cannot be expanded with aliases defined", route_labels[i]->aliases[0]);
+
+		for (j = 0; j < n_exp; j++) {
+			/* rename first entry */
+			if (j == 0)
+				route_labels[i]->aliases[0] = host_range[j];
+			/* replicate the source label, including pointers to content and options */
+			else {
+				route_labels[n_routes_ext] = xmalloc(sizeof(Label), "labels[]");
+				memcpy(route_labels[n_routes_ext], route_labels[i], sizeof(Label));
+				route_labels[n_routes_ext]->aliases[0] = host_range[j];
+				n_routes_ext++;
+
+				if (n_routes_ext == MAX_LABELS)
+					errx(1, "maximum number of labels (%d) exceeded while expanding '%s'",
+					    n_routes_ext, route_labels[i]->name);
+			}
+		}
+	}
+}
+
+/*
  * ltrim - strim leading characters
  */
 
@@ -264,12 +302,9 @@ read_label(char *line, Label *label) {
 	*export ++= '\0';
 	str_cpy(label->name, line, PLN_LABEL_SIZE);
 
-	label->n_aliases = str_to_array(label->aliases, label->name, PLN_MAX_ALIASES, ",");
-	if (label->n_aliases == PLN_MAX_ALIASES)
-		errx(1, "> %d aliases specified for label '%s'", PLN_MAX_ALIASES - 2, label->name);
-
-	if ((pln_mode == RouteLabel) && (label->n_aliases == 1))
-		label->n_aliases = expand_numeric_range(label->aliases, label->name, PLN_MAX_ALIASES);
+	label->n_aliases = str_to_array(label->aliases, label->name, PLN_MAX_ALIASES + 1, ",");
+	if (label->n_aliases > PLN_MAX_ALIASES)
+		errx(1, "> %d aliases specified for label '%s'", PLN_MAX_ALIASES, label->name);
 
 	len = str_to_array(label->export_paths, ltrim(export, ' '), PLN_MAX_PATHS, " ");
 	if ((label->export_paths[0] != NULL) && (pln_mode == HostLabel)) {
@@ -341,7 +376,7 @@ read_option(char *text, Options *op) {
 #define MAX_DIGITS 6
 
 int
-expand_numeric_range(char **argv, char *input, int max_elements) {
+expand_numeric_range(char **range, char *input) {
 	int ch;
 	int group;
 	int n;
@@ -433,18 +468,15 @@ expand_numeric_range(char **argv, char *input, int max_elements) {
 		if ((range_numeric[1] - range_numeric[0]) < 1)
 			errx(1, "non-ascending range: %d..%d", range_numeric[0], range_numeric[1]);
 
-		if ((range_numeric[1] - range_numeric[0]) > max_elements)
-			errx(1, "maximum range exceeds %d", max_elements);
+		if ((range_numeric[1] - range_numeric[0]) > MAX_LABELS)
+			errx(1, "maximum range exceeds %d", MAX_LABELS);
 
 		for (seq = range_numeric[0]; seq <= range_numeric[1]; seq++) {
-			asprintf(&argv[hostcount], "%s%d%s", parts[0], seq, parts[1]);
+			asprintf(&range[hostcount], "%s%d%s", parts[0], seq, parts[1]);
 			hostcount++;
 		}
-	} else {
-		argv[0] = (char *) input;
-		hostcount = 1;
 	}
-	argv[hostcount] = NULL;
+	range[hostcount] = NULL;
 	return hostcount;
 }
 

--- a/input.c
+++ b/input.c
@@ -268,7 +268,7 @@ read_label(char *line, Label *label) {
 	if (label->n_aliases == PLN_MAX_ALIASES)
 		errx(1, "> %d aliases specified for label '%s'", PLN_MAX_ALIASES - 2, label->name);
 
-	if (label->n_aliases == 1)
+	if ((pln_mode == RouteLabel) && (label->n_aliases == 1))
 		label->n_aliases = expand_numeric_range(label->aliases, label->name, PLN_MAX_ALIASES);
 
 	len = str_to_array(label->export_paths, ltrim(export, ' '), PLN_MAX_PATHS, " ");

--- a/input.h
+++ b/input.h
@@ -14,7 +14,7 @@
 #define PLN_LABEL_SIZE 128
 #define PLN_OPTION_SIZE 90
 #define PLN_MAX_PATHS 32
-#define PLN_MAX_ALIASES 100
+#define PLN_MAX_ALIASES 4
 
 #define MAX_ENVIRONMENT 20 * 1024
 
@@ -48,12 +48,13 @@ void erry(const char *fmt, ...);
 void parse_pln(Label **host_labels);
 void read_route_labels(const char *fn);
 void read_host_labels(Label *route_label);
+void expand_route_labels();
 Label **alloc_labels();
 
 char *ltrim(char *, int);
 void read_label(char *, Label *);
 void read_option(char *, Options *);
-int expand_numeric_range(char **, char *, int);
+int expand_numeric_range(char **, char *);
 char *env_split_lines(const char *, const char *, bool);
 char *read_environment_file(const char *);
 

--- a/rset.c
+++ b/rset.c
@@ -130,6 +130,7 @@ main(int argc, char *argv[]) {
 	/* parse route labels */
 	route_labels = alloc_labels();
 	read_route_labels(routes_file);
+	expand_route_labels();
 
 	if ((rv = regcomp(&label_reg, label_pattern, REG_EXTENDED)) != 0) {
 		regerror(rv, &label_reg, buf, sizeof(buf));

--- a/tests/expected/recursive.json
+++ b/tests/expected/recursive.json
@@ -45,7 +45,45 @@
     ]
   },
   {
-    "aliases": ["relay1.local", "relay2.local", "relay3.local"],
+    "aliases": ["relay1.local"],
+    "export_paths": ["common/"],
+    "labels": [
+      {
+        "name": "chroot",
+        "content_size": 146,
+        "options": {
+          "environment": "",
+          "environment_file": "",
+          "interpreter": "",
+          "local_interpreter": "",
+          "execute_with": "doas",
+          "begin": "",
+          "end": ""
+        }
+      }
+    ]
+  },
+  {
+    "aliases": ["relay2.local"],
+    "export_paths": ["common/"],
+    "labels": [
+      {
+        "name": "chroot",
+        "content_size": 146,
+        "options": {
+          "environment": "",
+          "environment_file": "",
+          "interpreter": "",
+          "local_interpreter": "",
+          "execute_with": "doas",
+          "begin": "",
+          "end": ""
+        }
+      }
+    ]
+  },
+  {
+    "aliases": ["relay3.local"],
     "export_paths": ["common/"],
     "labels": [
       {

--- a/tests/hostlist.c
+++ b/tests/hostlist.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 
+#include "config.h"
 #include "input.h"
 
 /* globals */
@@ -7,7 +8,7 @@ Label **route_labels;
 
 int
 main(int argc, char **argv) {
-	char *hostlist[PLN_MAX_ALIASES];
+	char *hostlist[MAX_LABELS];
 	int n;
 	int n_hosts;
 
@@ -16,7 +17,7 @@ main(int argc, char **argv) {
 		return 1;
 	}
 
-	n_hosts = expand_numeric_range(hostlist, argv[1], 50);
+	n_hosts = expand_numeric_range(hostlist, argv[1]);
 	printf("(%d)\n", n_hosts);
 	for (n = 0; hostlist[n]; n++)
 		printf("%s\n", hostlist[n]);

--- a/tests/parser.c
+++ b/tests/parser.c
@@ -48,6 +48,7 @@ main(int argc, char *argv[]) {
 	switch (mode[0]) {
 	case 'R':
 		read_route_labels(fn);
+		expand_route_labels();
 		break;
 	case 'H':
 		route_labels[0] = xmalloc(sizeof(Label), "route_labels[]");

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -417,8 +417,7 @@ try 'Simple hostlist' do
   out, err, status = Open3.capture3(cmd)
   eq err, ''
   eq out, <<~RESULT
-    (1)
-    web12.dev
+    (0)
   RESULT
   eq status.success?, true
 end
@@ -466,7 +465,7 @@ try 'Invalid hostlist range' do
 
   cmd = "./hostlist 'web{1..9999}.dev'"
   out, err, status = Open3.capture3(cmd)
-  eq err, "hostlist: maximum range exceeds 50\n"
+  eq err, "hostlist: maximum range exceeds 100\n"
   eq out, ''
   eq status.success?, false
 end


### PR DESCRIPTION
Previously a range expression such as `kube{1..3}` was expanded as an array of aliases.  Extending the route list makes it possible to iterate over all distinct hosts.

Reduce `PLN_MAX_ALIASES` to 4, a value more appropriate for representing multiple addresses for the same target.
