### PR TITLE
Support hostname regex

### DIFF
--- a/pln.5
+++ b/pln.5
@@ -51,7 +51,7 @@ svc1.local: etc/ rc.d/
 	httpd.pln
 .Ed
 .Pp
-Labels may be split into multiple aliases separated by using commas
+Labels may be split into multiple aliases separated by commas
 .Bd -literal -offset indent
 svc1.local,10.0.0.10:
 	common.pln

--- a/rset.1
+++ b/rset.1
@@ -26,9 +26,13 @@
 evaluates script fragments written in Progressive Label Notation
 .Pq Xr pln 5 ,
 executing each script in sequence using ssh connection multiplexing.
+.Pp
 .Nm
-accepts one or more hostnames which match the labels in
+expects one or more hostnames matching labels in the
 .Ar routes_file .
+If arguments contain characters consistent with a valid network address, they
+are compared with all host aliases, otherwise they are treated as regular
+expressions.
 .Pp
 The arguments are as follows:
 .Bl -tag -width Ds

--- a/rset.c
+++ b/rset.c
@@ -29,11 +29,11 @@
 static void handle_exit(int sig);
 static void usage(bool);
 static char **set_options(int argc, char *argv[]);
-static char **compare_argv_routes(char *hostnames[]);
+static void compare_argv(char *args[], char *hostnames[], char *m_args[]);
 static void not_found(char *name);
 static void start_http_server(int stdout_pipe[], int http_port);
 static int execute_remote(char *hostnames[], regex_t *label_reg);
-static int dry_run(char *hostnames[], regex_t *label_reg);
+static int dry_run(char *hostnames[], char *m_args[], regex_t *label_reg);
 
 /* globals from input.h */
 Label **route_labels;
@@ -71,7 +71,7 @@ main(int argc, char *argv[]) {
 	int worker_argc[MAX_WORKERS];
 	int worker_pid[MAX_WORKERS];
 	char *renv_bin, *rinstall_bin, *rsub_bin;
-	char **args, **hostnames;
+	char **args, **hostnames, **m_args;
 	char **worker_argv[MAX_WORKERS];
 	char routes_realpath[PATH_MAX];
 	regex_t label_reg;
@@ -142,7 +142,9 @@ main(int argc, char *argv[]) {
 		read_host_labels(route_labels[i]);
 
 	/* generate list of matching hostnames */
-	hostnames = compare_argv_routes(args);
+	hostnames = xcalloc(MAX_LABELS, sizeof(char *), "hostnames");
+	m_args = xcalloc(MAX_LABELS, sizeof(char *), "m_args");
+	compare_argv(args, hostnames, m_args);
 
 	if (n_parallel > 0) {
 		n_workers = 0;
@@ -174,7 +176,7 @@ main(int argc, char *argv[]) {
 
 	/* main loop */
 	if (dryrun_opt) {
-		ret = dry_run(hostnames, &label_reg);
+		ret = dry_run(hostnames, m_args, &label_reg);
 		free(hostnames);
 		return ret;
 	}
@@ -355,9 +357,10 @@ execute_remote(char *hostnames[], regex_t *label_reg) {
  */
 
 static int
-dry_run(char *hostnames[], regex_t *label_reg) {
+dry_run(char *hostnames[], char *m_args[], regex_t *label_reg) {
 	int i, j, k, l;
 	regmatch_t regmatch;
+	regex_t route_reg;
 	Label **host_labels;
 
 	for (i = 0; route_labels[i]; i++) {
@@ -370,8 +373,13 @@ dry_run(char *hostnames[], regex_t *label_reg) {
 				else
 					continue;
 
-				hl_range(hostname, HL_HOST, 0, strlen(hostname));
+				if (regcomp(&route_reg, m_args[k], REG_EXTENDED) != 0)
+					errx(1, "invalid host pattern: %s", m_args[k]);
+				regexec(&route_reg, hostname, 1, &regmatch, 0);
+
+				hl_range(hostname, HL_HOST, regmatch.rm_so, regmatch.rm_eo);
 				printf("\n");
+
 				for (j = 0; host_labels[j]; j++) {
 					if (regexec(label_reg, host_labels[j]->name, 1, &regmatch, 0) != 0)
 						continue;
@@ -506,24 +514,38 @@ set_options(int argc, char *argv[]) {
 
 /* construct a list of hostnames matching routes */
 
-static char **
-compare_argv_routes(char *args[]) {
+static void
+compare_argv(char *args[], char *hostnames[], char *m_args[]) {
 	int i, j, k;
 	int labels_matched;
 	int n_hosts = 0;
-	char **hostnames;
-
-	hostnames = xcalloc(MAX_LABELS, sizeof(char *), "hostnames");
+	const char *match;
 
 	for (i = 0; args[i]; i++) {
 		labels_matched = 0;
 		for (j = 0; route_labels[j]; j++) {
-			for (k = 0; k < route_labels[j]->n_aliases; k++) {
-				if (strcmp(args[i], route_labels[j]->aliases[k]) == 0) {
-					hostnames[n_hosts] = route_labels[j]->aliases[k];
-					n_hosts++;
+			match = pattern_match(args[i], route_labels[j]->aliases[0]);
+
+			/* scan aliases for an exact match */
+			if (!match) {
+				for (k = 1; k < route_labels[j]->n_aliases; k++) {
+					if (strcmp(args[i], route_labels[j]->aliases[k]) == 0)
+						match = route_labels[j]->aliases[k];
+				}
+			}
+			/* skip if already exists to set of hosts */
+			for (k = 0; match && k < n_hosts; k++) {
+				if (strcmp(match, hostnames[k]) == 0) {
+					match = NULL;
 					labels_matched++;
 				}
+			}
+			/* add to list */
+			if (match) {
+				hostnames[n_hosts] = (char *) match;
+				m_args[n_hosts] = args[i];
+				n_hosts++;
+				labels_matched++;
 			}
 		}
 		if (labels_matched == 0)
@@ -531,7 +553,7 @@ compare_argv_routes(char *args[]) {
 	}
 
 	hostnames[n_hosts] = NULL;
-	return hostnames;
+	m_args[n_hosts] = NULL;
 }
 
 /* failure to locate utility */

--- a/rutils.c
+++ b/rutils.c
@@ -7,6 +7,7 @@
 #include <sys/wait.h>
 
 #include <err.h>
+#include <regex.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -190,6 +191,52 @@ hl_range(const char *s, const char *color, unsigned so, unsigned eo) {
 		free(start);
 		free(match);
 	}
+}
+
+/*
+ * pattern_match - match exact string or regular expression
+ */
+const char *
+pattern_match(const char *pattern, const char *string) {
+	char buf[_POSIX2_LINE_MAX];
+	char c;
+	int n, len;
+	int rv;
+	bool is_char, is_digit, is_dash, is_dot, is_colon;
+	bool try_regex = false;
+	const char *match = NULL;
+	regex_t label_reg;
+	regmatch_t regmatch;
+
+	/* test for input consistant with a valid hostname or address */
+	len = strlen(pattern);
+	for (n = 0; n < len; n++) {
+		c = pattern[n];
+		is_char = (c >= 'a') && (c <= 'z');
+		is_digit = (c >= '0') && (c <= '9');
+		is_dash = (c == '-') && (n > 0) && (n + 1 < len);
+		is_dot = (c == '.') && (n > 0) && (n + 1 < len);
+		is_colon = (c == ':') && (n + 1 < len);
+		if (is_char | is_digit | is_dash | is_dot | is_colon)
+			continue;
+		else
+			try_regex = true;
+	}
+
+	if (try_regex) {
+		if ((rv = regcomp(&label_reg, pattern, REG_EXTENDED)) != 0) {
+			regerror(rv, &label_reg, buf, sizeof(buf));
+			errx(1, "bad expression: %s", buf);
+		}
+		if (regexec(&label_reg, string, 1, &regmatch, 0) == 0) {
+			if (regmatch.rm_eo > regmatch.rm_so)
+				match = string;
+		}
+	} else {
+		if (strcmp(pattern, string) == 0)
+			match = string;
+	}
+	return match;
 }
 
 /*

--- a/rutils.h
+++ b/rutils.h
@@ -19,6 +19,7 @@ void check_permissions(const char *);
 int create_dir(const char *);
 void install_if_new(const char *, const char *);
 void hl_range(const char *, const char *, unsigned, unsigned);
+const char *pattern_match(const char *, const char *);
 void log_msg(char *, char *, char *, int);
 void trace_shell(char *);
 void trace_exec(char *[]);

--- a/tests/expected/dry_run_pattern.out
+++ b/tests/expected/dry_run_pattern.out
@@ -1,0 +1,6 @@
+[33m[7m127.0.0.1[0m[33m[0m
+[36m[7mc[0m[36mhroot[0m
+[36m[7mc[0m[36mommon packages[0m
+[36m[7md[0m[36mesktop[0m
+[33m[7mrelay1.[0m[33mlocal[0m
+[36m[7mc[0m[36mhroot[0m

--- a/tests/test_rset.rb
+++ b/tests/test_rset.rb
@@ -494,3 +494,26 @@ try 'Raise error if no route match is found' do
   eq err, "rset: No match for 'localhost.xyz' in routes.pln\n"
   eq status.success?, false
 end
+
+try 'Show routes matching a pattern' do
+  out, err, status = nil
+  cmd = "#{Dir.pwd}/../rset -n 'relay1.' 127.0.0.1"
+  Dir.chdir(@mynet) do
+    FileUtils.mkdir_p('_sources')
+    out, err, status = Open3.capture3(cmd)
+  end
+  eq err, ''
+  eq out, File.read('expected/dry_run_pattern.out')
+  eq status.success?, true
+end
+
+try 'Raise error if no route pattern match is found' do
+  FileUtils.mkdir_p("#{@systmp}/_sources")
+  out, err, status = nil
+  cmd = "#{Dir.pwd}/../rset -n '127.+'"
+  Dir.chdir(@mynet) do
+    out, err, status = Open3.capture3(cmd)
+  end
+  eq err, "rset: No match for '127.+' in routes.pln\n"
+  eq status.success?, false
+end


### PR DESCRIPTION
Arguments formatted as a hostname or an IP address remain an exact comparison between all host aliases. If an argument does not appear to be a valid hostname, it is treated as a regular expression and compared with only the first alias for each route entry.

The dry-run option will highlight the text matched for each route:

    rset -n kube[0-9]

Any pattern matching one or more characters is permitted. Hence, to configure all hosts a pattern of `.` or `.+` can be used.